### PR TITLE
Return an error when docID is missing for Get, Put, and Delete

### DIFF
--- a/db.go
+++ b/db.go
@@ -11,8 +11,11 @@ import (
 
 	"github.com/flimzy/kivik"
 	"github.com/flimzy/kivik/driver"
+	"github.com/flimzy/kivik/errors"
 	"github.com/go-kivik/couchdb/chttp"
 )
+
+var errDocIDRequired = errors.Status(kivik.StatusBadRequest, "kivik: docID required")
 
 type db struct {
 	*client
@@ -81,6 +84,9 @@ func (d *db) Query(ctx context.Context, ddoc, view string, opts map[string]inter
 
 // Get fetches the requested document.
 func (d *db) Get(ctx context.Context, docID string, opts map[string]interface{}) (json.RawMessage, error) {
+	if docID == "" {
+		return nil, errDocIDRequired
+	}
 	params, err := optionsToParams(opts)
 	if err != nil {
 		return nil, err
@@ -121,6 +127,9 @@ func (d *db) CreateDoc(ctx context.Context, doc interface{}) (docID, rev string,
 }
 
 func (d *db) Put(ctx context.Context, docID string, doc interface{}) (rev string, err error) {
+	if docID == "" {
+		return "", errDocIDRequired
+	}
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithCancel(ctx)
 	defer cancel()
@@ -148,6 +157,9 @@ func (d *db) Put(ctx context.Context, docID string, doc interface{}) (rev string
 }
 
 func (d *db) Delete(ctx context.Context, docID, rev string) (string, error) {
+	if docID == "" {
+		return "", errDocIDRequired
+	}
 	query := url.Values{}
 	query.Add("rev", rev)
 	opts := &chttp.Options{

--- a/db_test.go
+++ b/db_test.go
@@ -102,3 +102,99 @@ func TestOptionsToParams(t *testing.T) {
 		}(test)
 	}
 }
+
+func TestDBPut(t *testing.T) {
+	tests := []struct {
+		name   string
+		db     *db
+		docID  string
+		doc    interface{}
+		status int
+		err    string
+	}{
+		{
+			name:   "missing docID",
+			db:     &db{},
+			status: kivik.StatusBadRequest,
+			err:    "kivik: docID required",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := test.db.Put(context.Background(), test.docID, test.doc)
+			var errMsg string
+			var status int
+			if err != nil {
+				errMsg = err.Error()
+				status = kivik.StatusCode(err)
+			}
+			if errMsg != test.err || status != test.status {
+				t.Errorf("Unexpected error: %d / %s", status, errMsg)
+			}
+		})
+	}
+}
+
+func TestDBGet(t *testing.T) {
+	tests := []struct {
+		name   string
+		db     *db
+		docID  string
+		opts   map[string]interface{}
+		status int
+		err    string
+	}{
+		{
+			name:   "missing docID",
+			db:     &db{},
+			status: kivik.StatusBadRequest,
+			err:    "kivik: docID required",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := test.db.Get(context.Background(), test.docID, test.opts)
+			var errMsg string
+			var status int
+			if err != nil {
+				errMsg = err.Error()
+				status = kivik.StatusCode(err)
+			}
+			if errMsg != test.err || status != test.status {
+				t.Errorf("Unexpected error: %d / %s", status, errMsg)
+			}
+		})
+	}
+}
+
+func TestDBDelete(t *testing.T) {
+	tests := []struct {
+		name   string
+		db     *db
+		docID  string
+		rev    string
+		status int
+		err    string
+	}{
+		{
+			name:   "missing docID",
+			db:     &db{},
+			status: kivik.StatusBadRequest,
+			err:    "kivik: docID required",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := test.db.Delete(context.Background(), test.docID, test.rev)
+			var errMsg string
+			var status int
+			if err != nil {
+				errMsg = err.Error()
+				status = kivik.StatusCode(err)
+			}
+			if errMsg != test.err || status != test.status {
+				t.Errorf("Unexpected error: %d / %s", status, errMsg)
+			}
+		})
+	}
+}

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,7 +15,7 @@ import:
   - publicsuffix
 testImport:
 - package: github.com/flimzy/diff
-  version: ^0.1.1
+  version: ^0.1.2
 - package: github.com/go-kivik/kiviktest
   subpackages:
   - kt


### PR DESCRIPTION
Not doing so could be somewhat dangerous, in particular for Put and Delete,
where you might end up acting on a database rather than a document as
expected.

Fixes #3