### PR TITLE
CouchDB 2.1 support

### DIFF
--- a/test/couchdb21.go
+++ b/test/couchdb21.go
@@ -77,7 +77,7 @@ func registerSuiteCouch21() {
 
 		"Log.skip": true, // This was removed in CouchDB 2.0
 
-		"Version.version":        `^2\.0\.0$`,
+		"Version.version":        `^2\.1\.0$`,
 		"Version.vendor":         `^The Apache Software Foundation$`,
 		"Version.vendor_version": ``, // CouchDB 2.0 no longer has a vendor version
 

--- a/test/couchdb21.go
+++ b/test/couchdb21.go
@@ -166,8 +166,8 @@ func registerSuiteCouch21() {
 
 		// "DeleteAttachment/RW/group/Admin/NotFound.status":  kivik.StatusNotFound, // COUCHDB-3362
 		// "DeleteAttachment/RW/group/NoAuth/NotFound.status": kivik.StatusNotFound, // COUCHDB-3362
-		"DeleteAttachment/RW/group/Admin/NoDoc.status":      kivik.StatusInternalServerError,
-		"DeleteAttachment/RW/group/NoAuth/NoDoc.status":     kivik.StatusInternalServerError,
+		"DeleteAttachment/RW/group/Admin/NoDoc.status":      kivik.StatusConflict,
+		"DeleteAttachment/RW/group/NoAuth/NoDoc.status":     kivik.StatusConflict,
 		"DeleteAttachment/RW/group/NoAuth/DesignDoc.status": kivik.StatusUnauthorized,
 
 		"Put/RW/Admin/group/LeadingUnderscoreInID.status":  kivik.StatusBadRequest,

--- a/test/couchdb21.go
+++ b/test/couchdb21.go
@@ -211,8 +211,8 @@ func registerSuiteCouch21() {
 		"Replicate.timeoutSeconds":                              60,
 		"Replicate.prefix":                                      "http://localhost:5984/",
 		"Replicate/RW/NoAuth.status":                            kivik.StatusForbidden,
-		"Replicate/RW/Admin/group/MissingSource/Results.status": kivik.StatusInternalServerError,
-		"Replicate/RW/Admin/group/MissingTarget/Results.status": kivik.StatusInternalServerError,
+		"Replicate/RW/Admin/group/MissingSource/Results.status": kivik.StatusNotFound,
+		"Replicate/RW/Admin/group/MissingTarget/Results.status": kivik.StatusNotFound,
 
 		"Query/RW/group/Admin/WithoutDocs/ScanDoc.status":  kivik.StatusBadRequest,
 		"Query/RW/group/NoAuth/WithoutDocs/ScanDoc.status": kivik.StatusBadRequest,

--- a/test/couchdb21.go
+++ b/test/couchdb21.go
@@ -133,7 +133,8 @@ func registerSuiteCouch21() {
 		"Stats/NoAuth/chicken.status": kivik.StatusNotFound,
 		"Stats/NoAuth/_duck.status":   kivik.StatusUnauthorized,
 
-		"Compact.skip": false,
+		"Compact.skip":             false,
+		"Compact/RW/NoAuth.status": kivik.StatusUnauthorized,
 
 		"Security.databases":                     []string{"_replicator", "_users", "_global_changes", "chicken", "_duck"},
 		"Security/Admin/chicken.status":          kivik.StatusNotFound,

--- a/test/couchdb21.go
+++ b/test/couchdb21.go
@@ -216,5 +216,7 @@ func registerSuiteCouch21() {
 
 		"Query/RW/group/Admin/WithoutDocs/ScanDoc.status":  kivik.StatusBadRequest,
 		"Query/RW/group/NoAuth/WithoutDocs/ScanDoc.status": kivik.StatusBadRequest,
+
+		"ViewCleanup/RW/NoAuth.status": kivik.StatusUnauthorized,
 	})
 }

--- a/test/couchdb21.go
+++ b/test/couchdb21.go
@@ -37,6 +37,33 @@ func registerSuiteCouch21() {
 		"Explain/Admin/_duck.status":    kivik.StatusNotFound,
 		"Explain/NoAuth/chicken.status": kivik.StatusNotFound,
 		"Explain/NoAuth/_duck.status":   kivik.StatusUnauthorized,
+		"Explain.plan": &kivik.QueryPlan{
+			Index: map[string]interface{}{
+				"ddoc": nil,
+				"name": "_all_docs",
+				"type": "special",
+				"def":  map[string]interface{}{"fields": []interface{}{map[string]string{"_id": "asc"}}},
+			},
+			Selector: map[string]interface{}{"_id": map[string]interface{}{"$gt": nil}},
+			Options: map[string]interface{}{
+				"bookmark":  "nil",
+				"conflicts": false,
+				"r":         []int{49},
+				"sort":      map[string]interface{}{},
+				"use_index": []interface{}{},
+				"stable":    false,
+				"stale":     false,
+				"update":    true,
+				"skip":      0,
+				"limit":     25,
+				"fields":    "all_fields",
+			},
+			Range: map[string]interface{}{
+				"start_key": nil,
+				"end_key":   "\xef\xbf\xbd",
+			},
+			Limit: 25,
+		},
 
 		"DBExists.databases":              []string{"_users", "chicken", "_duck"},
 		"DBExists/Admin/_users.exists":    true,

--- a/test/couchdb21.go
+++ b/test/couchdb21.go
@@ -159,8 +159,8 @@ func registerSuiteCouch21() {
 		"GetAttachmentMeta/RW/group/Admin/foo/NotFound.status":  kivik.StatusNotFound,
 		"GetAttachmentMeta/RW/group/NoAuth/foo/NotFound.status": kivik.StatusNotFound,
 
-		"PutAttachment/RW/group/Admin/Conflict.status":         kivik.StatusInternalServerError, // COUCHDB-3361
-		"PutAttachment/RW/group/NoAuth/Conflict.status":        kivik.StatusInternalServerError, // COUCHDB-3361
+		"PutAttachment/RW/group/Admin/Conflict.status":         kivik.StatusConflict,
+		"PutAttachment/RW/group/NoAuth/Conflict.status":        kivik.StatusConflict,
 		"PutAttachment/RW/group/NoAuth/UpdateDesignDoc.status": kivik.StatusUnauthorized,
 		"PutAttachment/RW/group/NoAuth/CreateDesignDoc.status": kivik.StatusUnauthorized,
 

--- a/test/couchdb21.go
+++ b/test/couchdb21.go
@@ -1,0 +1,192 @@
+package test
+
+import (
+	"github.com/flimzy/kivik"
+	"github.com/go-kivik/kiviktest"
+	"github.com/go-kivik/kiviktest/kt"
+)
+
+func registerSuiteCouch21() {
+	kiviktest.RegisterSuite(kiviktest.SuiteCouch21, kt.SuiteConfig{
+		"AllDBs.expected": []string{"_global_changes", "_replicator", "_users"},
+
+		"CreateDB/RW/NoAuth.status":         kivik.StatusUnauthorized,
+		"CreateDB/RW/Admin/Recreate.status": kivik.StatusPreconditionFailed,
+
+		"DestroyDB/RW/NoAuth.status":              kivik.StatusUnauthorized,
+		"DestroyDB/RW/Admin/NonExistantDB.status": kivik.StatusNotFound,
+
+		"AllDocs.databases":                 []string{"chicken", "_duck"},
+		"AllDocs/Admin/_replicator.offset":  0,
+		"AllDocs/Admin/chicken.status":      kivik.StatusNotFound,
+		"AllDocs/Admin/_duck.status":        kivik.StatusNotFound,
+		"AllDocs/NoAuth/_replicator.status": kivik.StatusUnauthorized,
+		"AllDocs/NoAuth/chicken.status":     kivik.StatusNotFound,
+		"AllDocs/NoAuth/_duck.status":       kivik.StatusUnauthorized,
+
+		"Find.databases":                       []string{"chicken", "_duck"},
+		"Find/Admin/chicken.status":            kivik.StatusNotFound,
+		"Find/Admin/_duck.status":              kivik.StatusNotFound,
+		"Find/NoAuth/chicken.status":           kivik.StatusNotFound,
+		"Find/NoAuth/_duck.status":             kivik.StatusUnauthorized,
+		"Find/RW/group/Admin/Warning.warning":  "no matching index found, create an index to optimize query time",
+		"Find/RW/group/NoAuth/Warning.warning": "no matching index found, create an index to optimize query time",
+
+		"Explain.databases":             []string{"chicken", "_duck"},
+		"Explain/Admin/chicken.status":  kivik.StatusNotFound,
+		"Explain/Admin/_duck.status":    kivik.StatusNotFound,
+		"Explain/NoAuth/chicken.status": kivik.StatusNotFound,
+		"Explain/NoAuth/_duck.status":   kivik.StatusUnauthorized,
+
+		"DBExists.databases":              []string{"_users", "chicken", "_duck"},
+		"DBExists/Admin/_users.exists":    true,
+		"DBExists/Admin/chicken.exists":   false,
+		"DBExists/Admin/_duck.exists":     false,
+		"DBExists/NoAuth/_users.exists":   true,
+		"DBExists/NoAuth/chicken.exists":  false,
+		"DBExists/NoAuth/_duck.status":    kivik.StatusUnauthorized,
+		"DBExists/RW/group/Admin.exists":  true,
+		"DBExists/RW/group/NoAuth.exists": true,
+
+		"Log.skip": true, // This was removed in CouchDB 2.0
+
+		"Version.version":        `^2\.0\.0$`,
+		"Version.vendor":         `^The Apache Software Foundation$`,
+		"Version.vendor_version": ``, // CouchDB 2.0 no longer has a vendor version
+
+		"Get/RW/group/Admin/bogus.status":  kivik.StatusNotFound,
+		"Get/RW/group/NoAuth/bogus.status": kivik.StatusNotFound,
+
+		"Rev/RW/group/Admin/bogus.status":  kivik.StatusNotFound,
+		"Rev/RW/group/NoAuth/bogus.status": kivik.StatusNotFound,
+
+		"Flush.databases":                     []string{"_users", "chicken", "_duck"},
+		"Flush/NoAuth/chicken/DoFlush.status": kivik.StatusNotFound,
+		"Flush/Admin/chicken/DoFlush.status":  kivik.StatusNotFound,
+		"Flush/Admin/_duck/DoFlush.status":    kivik.StatusNotFound,
+		"Flush/NoAuth/_duck/DoFlush.status":   kivik.StatusUnauthorized,
+
+		"Delete/RW/Admin/group/MissingDoc.status":        kivik.StatusNotFound,
+		"Delete/RW/Admin/group/InvalidRevFormat.status":  kivik.StatusBadRequest,
+		"Delete/RW/Admin/group/WrongRev.status":          kivik.StatusConflict,
+		"Delete/RW/NoAuth/group/MissingDoc.status":       kivik.StatusNotFound,
+		"Delete/RW/NoAuth/group/InvalidRevFormat.status": kivik.StatusBadRequest,
+		"Delete/RW/NoAuth/group/WrongRev.status":         kivik.StatusConflict,
+		"Delete/RW/NoAuth/group/DesignDoc.status":        kivik.StatusUnauthorized,
+
+		"Session/Get/Admin.info.authentication_handlers":  "cookie,default",
+		"Session/Get/Admin.info.authentication_db":        "_users",
+		"Session/Get/Admin.info.authenticated":            "cookie",
+		"Session/Get/Admin.userCtx.roles":                 "_admin",
+		"Session/Get/Admin.ok":                            "true",
+		"Session/Get/NoAuth.info.authentication_handlers": "cookie,default",
+		"Session/Get/NoAuth.info.authentication_db":       "_users",
+		"Session/Get/NoAuth.info.authenticated":           "",
+		"Session/Get/NoAuth.userCtx.roles":                "",
+		"Session/Get/NoAuth.ok":                           "true",
+
+		"Session/Post/EmptyJSON.status":                             kivik.StatusBadRequest,
+		"Session/Post/BogusTypeJSON.status":                         kivik.StatusBadRequest,
+		"Session/Post/BogusTypeForm.status":                         kivik.StatusBadRequest,
+		"Session/Post/EmptyForm.status":                             kivik.StatusBadRequest,
+		"Session/Post/BadJSON.status":                               kivik.StatusBadRequest,
+		"Session/Post/BadForm.status":                               kivik.StatusBadRequest,
+		"Session/Post/MeaninglessJSON.status":                       kivik.StatusInternalServerError,
+		"Session/Post/MeaninglessForm.status":                       kivik.StatusBadRequest,
+		"Session/Post/GoodJSON.status":                              kivik.StatusUnauthorized,
+		"Session/Post/BadQueryParam.status":                         kivik.StatusUnauthorized,
+		"Session/Post/BadCredsJSON.status":                          kivik.StatusUnauthorized,
+		"Session/Post/BadCredsForm.status":                          kivik.StatusUnauthorized,
+		"Session/Post/GoodCredsJSONRemoteRedirHeaderInjection.skip": true, // CouchDB allows header injection
+		"Session/Post/GoodCredsJSONRemoteRedirInvalidURL.skip":      true, // CouchDB doesn't sanitize the Location value, so sends unparseable headers.
+
+		"Stats.databases":             []string{"_users", "chicken", "_duck"},
+		"Stats/Admin/chicken.status":  kivik.StatusNotFound,
+		"Stats/Admin/_duck.status":    kivik.StatusNotFound,
+		"Stats/NoAuth/chicken.status": kivik.StatusNotFound,
+		"Stats/NoAuth/_duck.status":   kivik.StatusUnauthorized,
+
+		"Compact.skip": false,
+
+		"Security.databases":                     []string{"_replicator", "_users", "_global_changes", "chicken", "_duck"},
+		"Security/Admin/chicken.status":          kivik.StatusNotFound,
+		"Security/Admin/_duck.status":            kivik.StatusNotFound,
+		"Security/NoAuth/_global_changes.status": kivik.StatusUnauthorized,
+		"Security/NoAuth/chicken.status":         kivik.StatusNotFound,
+		"Security/NoAuth/_duck.status":           kivik.StatusUnauthorized,
+		"Security/RW/group/NoAuth.status":        kivik.StatusUnauthorized,
+
+		"SetSecurity/RW/Admin/NotExists.status":  kivik.StatusNotFound,
+		"SetSecurity/RW/NoAuth/NotExists.status": kivik.StatusNotFound,
+		"SetSecurity/RW/NoAuth/Exists.status":    kivik.StatusInternalServerError, // Can you say WTF?
+
+		"DBUpdates/RW/NoAuth.status": kivik.StatusUnauthorized,
+
+		"BulkDocs/RW/NoAuth/group/Mix/Conflict.status": kivik.StatusConflict,
+		"BulkDocs/RW/Admin/group/Mix/Conflict.status":  kivik.StatusConflict,
+
+		"GetAttachment/RW/group/Admin/foo/NotFound.status":  kivik.StatusNotFound,
+		"GetAttachment/RW/group/NoAuth/foo/NotFound.status": kivik.StatusNotFound,
+
+		"GetAttachmentMeta/RW/group/Admin/foo/NotFound.status":  kivik.StatusNotFound,
+		"GetAttachmentMeta/RW/group/NoAuth/foo/NotFound.status": kivik.StatusNotFound,
+
+		"PutAttachment/RW/group/Admin/Conflict.status":         kivik.StatusInternalServerError, // COUCHDB-3361
+		"PutAttachment/RW/group/NoAuth/Conflict.status":        kivik.StatusInternalServerError, // COUCHDB-3361
+		"PutAttachment/RW/group/NoAuth/UpdateDesignDoc.status": kivik.StatusUnauthorized,
+		"PutAttachment/RW/group/NoAuth/CreateDesignDoc.status": kivik.StatusUnauthorized,
+
+		// "DeleteAttachment/RW/group/Admin/NotFound.status":  kivik.StatusNotFound, // COUCHDB-3362
+		// "DeleteAttachment/RW/group/NoAuth/NotFound.status": kivik.StatusNotFound, // COUCHDB-3362
+		"DeleteAttachment/RW/group/Admin/NoDoc.status":      kivik.StatusInternalServerError,
+		"DeleteAttachment/RW/group/NoAuth/NoDoc.status":     kivik.StatusInternalServerError,
+		"DeleteAttachment/RW/group/NoAuth/DesignDoc.status": kivik.StatusUnauthorized,
+
+		"Put/RW/Admin/group/LeadingUnderscoreInID.status":  kivik.StatusBadRequest,
+		"Put/RW/Admin/group/Conflict.status":               kivik.StatusConflict,
+		"Put/RW/NoAuth/group/LeadingUnderscoreInID.status": kivik.StatusBadRequest,
+		"Put/RW/NoAuth/group/DesignDoc.status":             kivik.StatusUnauthorized,
+		"Put/RW/NoAuth/group/Conflict.status":              kivik.StatusConflict,
+
+		"CreateIndex/RW/Admin/group/EmptyIndex.status":    kivik.StatusBadRequest,
+		"CreateIndex/RW/Admin/group/BlankIndex.status":    kivik.StatusBadRequest,
+		"CreateIndex/RW/Admin/group/InvalidIndex.status":  kivik.StatusBadRequest,
+		"CreateIndex/RW/Admin/group/NilIndex.status":      kivik.StatusBadRequest,
+		"CreateIndex/RW/Admin/group/InvalidJSON.status":   kivik.StatusBadRequest,
+		"CreateIndex/RW/NoAuth/group/EmptyIndex.status":   kivik.StatusBadRequest,
+		"CreateIndex/RW/NoAuth/group/BlankIndex.status":   kivik.StatusBadRequest,
+		"CreateIndex/RW/NoAuth/group/InvalidIndex.status": kivik.StatusBadRequest,
+		"CreateIndex/RW/NoAuth/group/NilIndex.status":     kivik.StatusBadRequest,
+		"CreateIndex/RW/NoAuth/group/InvalidJSON.status":  kivik.StatusBadRequest,
+		"CreateIndex/RW/NoAuth/group/Valid.status":        kivik.StatusInternalServerError, // COUCHDB-3374
+
+		"GetIndexes.databases":                      []string{"_replicator", "_users", "_global_changes", "chicken", "_duck"},
+		"GetIndexes/Admin/_replicator.indexes":      []kivik.Index{kt.AllDocsIndex},
+		"GetIndexes/Admin/_users.indexes":           []kivik.Index{kt.AllDocsIndex},
+		"GetIndexes/Admin/_global_changes.indexes":  []kivik.Index{kt.AllDocsIndex},
+		"GetIndexes/Admin/chicken.status":           kivik.StatusNotFound,
+		"GetIndexes/Admin/_duck.status":             kivik.StatusNotFound,
+		"GetIndexes/NoAuth/_replicator.indexes":     []kivik.Index{kt.AllDocsIndex},
+		"GetIndexes/NoAuth/_users.indexes":          []kivik.Index{kt.AllDocsIndex},
+		"GetIndexes/NoAuth/_global_changes.indexes": []kivik.Index{kt.AllDocsIndex},
+		"GetIndexes/NoAuth/chicken.status":          kivik.StatusNotFound,
+		"GetIndexes/NoAuth/_duck.status":            kivik.StatusNotFound,
+
+		"DeleteIndex/RW/Admin/group/NotFoundDdoc.status":  kivik.StatusNotFound,
+		"DeleteIndex/RW/Admin/group/NotFoundName.status":  kivik.StatusNotFound,
+		"DeleteIndex/RW/NoAuth/group/NotFoundDdoc.status": kivik.StatusNotFound,
+		"DeleteIndex/RW/NoAuth/group/NotFoundName.status": kivik.StatusNotFound,
+
+		"GetReplications/NoAuth.status": kivik.StatusUnauthorized,
+
+		"Replicate.NotFoundDB":                                  "http://localhost:5984/foo",
+		"Replicate.timeoutSeconds":                              60,
+		"Replicate.prefix":                                      "http://localhost:5984/",
+		"Replicate/RW/NoAuth.status":                            kivik.StatusForbidden,
+		"Replicate/RW/Admin/group/MissingSource/Results.status": kivik.StatusInternalServerError,
+		"Replicate/RW/Admin/group/MissingTarget/Results.status": kivik.StatusInternalServerError,
+
+		"Query/RW/group/Admin/WithoutDocs/ScanDoc.status":  kivik.StatusBadRequest,
+		"Query/RW/group/NoAuth/WithoutDocs/ScanDoc.status": kivik.StatusBadRequest,
+	})
+}

--- a/test/couchdb_test.go
+++ b/test/couchdb_test.go
@@ -17,10 +17,14 @@ func TestCouch16(t *testing.T) {
 	kiviktest.DoTest(kiviktest.SuiteCouch16, "KIVIK_TEST_DSN_COUCH16", t)
 }
 
-func TestCloudant(t *testing.T) {
-	kiviktest.DoTest(kiviktest.SuiteCloudant, "KIVIK_TEST_DSN_CLOUDANT", t)
-}
-
 func TestCouch20(t *testing.T) {
 	kiviktest.DoTest(kiviktest.SuiteCouch20, "KIVIK_TEST_DSN_COUCH20", t)
+}
+
+func TestCouch21(t *testing.T) {
+	kiviktest.DoTest(kiviktest.SuiteCouch21, "KIVIK_TEST_DSN_COUCH21", t)
+}
+
+func TestCloudant(t *testing.T) {
+	kiviktest.DoTest(kiviktest.SuiteCloudant, "KIVIK_TEST_DSN_CLOUDANT", t)
 }

--- a/test/test.go
+++ b/test/test.go
@@ -4,5 +4,6 @@ package test
 func RegisterCouchDBSuites() {
 	registerSuiteCouch16()
 	registerSuiteCouch20()
+	registerSuiteCouch21()
 	registerSuiteCloudant()
 }

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -47,10 +47,24 @@ function setup_couch20 {
     curl --silent --fail -o /dev/null -X PUT http://admin:abc123@localhost:6001/_global_changes
 }
 
+function setup_couch21 {
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        return
+    fi
+    docker pull apache/couchdb:2.1.0
+    docker run -d -p 6002:5984 -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=abc123 --name couchdb21 apache/couchdb:2.1.0
+    wait_for_server http://localhost:6002/
+    curl --silent --fail -o /dev/null -X PUT http://admin:abc123@localhost:6002/_users
+    curl --silent --fail -o /dev/null -X PUT http://admin:abc123@localhost:6002/_replicator
+    curl --silent --fail -o /dev/null -X PUT http://admin:abc123@localhost:6002/_global_changes
+    curl --silent --fail -o /dev/null -X PUT http://admin:abc123@localhost:6002/_node/nonode@nohost/_config/replicator/update_docs -H 'Content-Type: application/json' -d '"true"' # FIXME: https://github.com/flimzy/kivik/issues/215
+}
+
 case "$1" in
     "standard")
         setup_couch16
         setup_couch20
+        setup_couch21
         generate
     ;;
     "linter")


### PR DESCRIPTION
This PR just gets the test suite passing against a CouchDB 2.1 docker image. This doesn't add support for any new features found in 2.1.