### PR TITLE
Rename force commit to full commit

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -74,16 +74,16 @@ func (d *db) BulkDocs(ctx context.Context, docs []interface{}, options map[strin
 	if options == nil {
 		options = make(map[string]interface{})
 	}
-	forceCommit := d.forceCommit
+	fullCommit := d.fullCommit
 	if fc, ok := options[OptionFullCommit].(bool); ok {
-		forceCommit = fc
+		fullCommit = fc
 	}
 	delete(options, OptionFullCommit)
 	options["docs"] = docs
 	body, errFunc := chttp.EncodeBody(options, cancel)
 	opts := &chttp.Options{
-		Body:        body,
-		ForceCommit: forceCommit,
+		Body:       body,
+		FullCommit: fullCommit,
 	}
 	resp, err := d.Client.DoReq(ctx, kivik.MethodPost, d.path("_bulk_docs", nil), opts)
 	if jsonErr := errFunc(); jsonErr != nil {

--- a/bulk.go
+++ b/bulk.go
@@ -74,11 +74,10 @@ func (d *db) BulkDocs(ctx context.Context, docs []interface{}, options map[strin
 	if options == nil {
 		options = make(map[string]interface{})
 	}
-	fullCommit := d.fullCommit
-	if fc, ok := options[OptionFullCommit].(bool); ok {
-		fullCommit = fc
+	fullCommit, err := fullCommit(d.fullCommit, options)
+	if err != nil {
+		return nil, err
 	}
-	delete(options, OptionFullCommit)
 	options["docs"] = docs
 	body, errFunc := chttp.EncodeBody(options, cancel)
 	opts := &chttp.Options{

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -125,7 +125,7 @@ func TestBulkDocs(t *testing.T) {
 			db:      &db{},
 			options: map[string]interface{}{OptionFullCommit: 123},
 			status:  kivik.StatusBadRequest,
-			err:     "kivik: option 'full-commit' must be bool, not int",
+			err:     "kivik: option 'X-Couch-Full-Commit' must be bool, not int",
 		},
 	}
 	for _, test := range tests {

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -100,16 +100,16 @@ func TestBulkDocs(t *testing.T) {
 			}),
 		},
 		{
-			name:    "force_commit",
-			options: map[string]interface{}{"force_commit": true},
+			name:    "full commit",
+			options: map[string]interface{}{OptionFullCommit: true},
 			db: newCustomDB(func(req *http.Request) (*http.Response, error) {
 				defer req.Body.Close() // nolint: errcheck
 				var body map[string]interface{}
 				if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 					return nil, err
 				}
-				if _, ok := body["force_commit"]; ok {
-					return nil, errors.New("force_commit key found in body")
+				if _, ok := body[OptionFullCommit]; ok {
+					return nil, errors.New("Full Commit key found in body")
 				}
 				if value := req.Header.Get("X-Couch-Full-Commit"); value != "true" {
 					return nil, errors.New("X-Couch-Full-Commit not set to true")

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -120,6 +120,13 @@ func TestBulkDocs(t *testing.T) {
 				}, nil
 			}),
 		},
+		{
+			name:    "invalid full commit type",
+			db:      &db{},
+			options: map[string]interface{}{OptionFullCommit: 123},
+			status:  kivik.StatusBadRequest,
+			err:     "kivik: option 'full-commit' must be bool, not int",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/chttp/chttp.go
+++ b/chttp/chttp.go
@@ -100,8 +100,8 @@ type Options struct {
 	// encoding, so that the request can be live on the wire during JSON
 	// encoding.
 	JSON interface{}
-	// ForceCommit adds the X-Couch-Full-Commit: true header to requests
-	ForceCommit bool
+	// FullCommit adds the X-Couch-Full-Commit: true header to requests
+	FullCommit bool
 	// Destination is the target ID for COPY
 	Destination string
 }
@@ -213,7 +213,7 @@ func setHeaders(req *http.Request, opts *Options) {
 		if opts.ContentType != "" {
 			contentType = opts.ContentType
 		}
-		if opts.ForceCommit {
+		if opts.FullCommit {
 			req.Header.Add("X-Couch-Full-Commit", "true")
 		}
 		if opts.Destination != "" {

--- a/chttp/chttp_test.go
+++ b/chttp/chttp_test.go
@@ -209,8 +209,8 @@ func TestSetHeaders(t *testing.T) {
 			},
 		},
 		{
-			Name:    "ForceCommit",
-			Options: &Options{ForceCommit: true},
+			Name:    "FullCommit",
+			Options: &Options{FullCommit: true},
 			Expected: http.Header{
 				"Accept":              []string{"application/json"},
 				"Content-Type":        []string{"application/json"},

--- a/constants.go
+++ b/constants.go
@@ -6,7 +6,7 @@ package couchdb
 // Example:
 //
 //    db.Put(ctx, "doc_id", doc, kivik.Options{couchdb.ForceCommitOptionKey: true})
-const OptionFullCommit = "full-commit"
+const OptionFullCommit = "X-Couch-Full-Commit"
 
 // optionForceCommit is an unfortunately mispelled version of "full-commit",
 // retained for backward compatibility.

--- a/constants.go
+++ b/constants.go
@@ -6,4 +6,8 @@ package couchdb
 // Example:
 //
 //    db.Put(ctx, "doc_id", doc, kivik.Options{couchdb.ForceCommitOptionKey: true})
-const OptionFullCommit = "force_commit"
+const OptionFullCommit = "full-commit"
+
+// optionForceCommit is an unfortunately mispelled version of "full-commit",
+// retained for backward compatibility.
+const optionForceCommit = "force_commit"

--- a/couchdb.go
+++ b/couchdb.go
@@ -104,7 +104,7 @@ func (c *client) DB(_ context.Context, dbName string, options map[string]interfa
 	if dbName == "" {
 		return nil, missingArg("dbName")
 	}
-	fullCommit, err := fullCommit(options)
+	fullCommit, err := fullCommit(false, options)
 	if err != nil {
 		return nil, err
 	}

--- a/couchdb.go
+++ b/couchdb.go
@@ -104,14 +104,14 @@ func (c *client) DB(_ context.Context, dbName string, options map[string]interfa
 	if dbName == "" {
 		return nil, missingArg("dbName")
 	}
-	forceCommit, err := forceCommit(options)
+	fullCommit, err := fullCommit(options)
 	if err != nil {
 		return nil, err
 	}
 	return &db{
-		client:      c,
-		dbName:      dbName,
-		forceCommit: forceCommit,
+		client:     c,
+		dbName:     dbName,
+		fullCommit: fullCommit,
 	}, nil
 }
 

--- a/couchdb_test.go
+++ b/couchdb_test.go
@@ -169,23 +169,23 @@ func TestDB(t *testing.T) {
 			err:    "kivik: dbName required",
 		},
 		{
-			name:    "invalid force type",
+			name:    "invalid full commit type",
 			dbName:  "foo",
 			options: map[string]interface{}{OptionFullCommit: 123},
 			status:  kivik.StatusBadRequest,
-			err:     "kivik: option 'force_commit' must be bool, not int",
+			err:     "kivik: option 'full-commit' must be bool, not int",
 		},
 		{
-			name:    "force commit",
+			name:    "full commit",
 			dbName:  "foo",
 			options: map[string]interface{}{OptionFullCommit: true},
 			expected: &db{
-				dbName:      "foo",
-				forceCommit: true,
+				dbName:     "foo",
+				fullCommit: true,
 			},
 		},
 		{
-			name:   "no force commit",
+			name:   "no full commit",
 			dbName: "foo",
 			expected: &db{
 				dbName: "foo",

--- a/couchdb_test.go
+++ b/couchdb_test.go
@@ -173,7 +173,7 @@ func TestDB(t *testing.T) {
 			dbName:  "foo",
 			options: map[string]interface{}{OptionFullCommit: 123},
 			status:  kivik.StatusBadRequest,
-			err:     "kivik: option 'full-commit' must be bool, not int",
+			err:     "kivik: option 'X-Couch-Full-Commit' must be bool, not int",
 		},
 		{
 			name:    "full commit",

--- a/db.go
+++ b/db.go
@@ -279,11 +279,10 @@ func (d *db) Copy(ctx context.Context, targetID, sourceID string, options map[st
 	if err != nil {
 		return "", err
 	}
-	fullCommit := d.fullCommit
-	if fc, ok := options[OptionFullCommit].(bool); ok {
-		fullCommit = fc
+	fullCommit, err := fullCommit(d.fullCommit, options)
+	if err != nil {
+		return "", err
 	}
-	delete(options, OptionFullCommit)
 	opts := &chttp.Options{
 		FullCommit:  fullCommit,
 		Destination: targetID,

--- a/db.go
+++ b/db.go
@@ -17,8 +17,8 @@ import (
 
 type db struct {
 	*client
-	dbName      string
-	forceCommit bool
+	dbName     string
+	fullCommit bool
 }
 
 func (d *db) path(path string, query url.Values) string {
@@ -114,8 +114,8 @@ func (d *db) CreateDoc(ctx context.Context, doc interface{}) (docID, rev string,
 	defer cancel()
 	body, errFunc := chttp.EncodeBody(doc, cancel)
 	opts := &chttp.Options{
-		Body:        body,
-		ForceCommit: d.forceCommit,
+		Body:       body,
+		FullCommit: d.fullCommit,
 	}
 	_, err = d.Client.DoJSON(ctx, kivik.MethodPost, d.dbName, opts, &result)
 	if jsonErr := errFunc(); jsonErr != nil {
@@ -133,8 +133,8 @@ func (d *db) Put(ctx context.Context, docID string, doc interface{}) (rev string
 	defer cancel()
 	body, errFunc := chttp.EncodeBody(doc, cancel)
 	opts := &chttp.Options{
-		Body:        body,
-		ForceCommit: d.forceCommit,
+		Body:       body,
+		FullCommit: d.fullCommit,
 	}
 	var result struct {
 		ID  string `json:"id"`
@@ -161,7 +161,7 @@ func (d *db) Delete(ctx context.Context, docID, rev string) (string, error) {
 	query := url.Values{}
 	query.Add("rev", rev)
 	opts := &chttp.Options{
-		ForceCommit: d.forceCommit,
+		FullCommit: d.fullCommit,
 	}
 	resp, err := d.Client.DoReq(ctx, kivik.MethodDelete, d.path(chttp.EncodeDocID(docID), query), opts)
 	if err != nil {
@@ -279,13 +279,13 @@ func (d *db) Copy(ctx context.Context, targetID, sourceID string, options map[st
 	if err != nil {
 		return "", err
 	}
-	forceCommit := d.forceCommit
+	fullCommit := d.fullCommit
 	if fc, ok := options[OptionFullCommit].(bool); ok {
-		forceCommit = fc
+		fullCommit = fc
 	}
 	delete(options, OptionFullCommit)
 	opts := &chttp.Options{
-		ForceCommit: forceCommit,
+		FullCommit:  fullCommit,
 		Destination: targetID,
 	}
 	resp, err := d.Client.DoReq(ctx, kivik.MethodCopy, d.path(chttp.EncodeDocID(sourceID), params), opts)

--- a/db_test.go
+++ b/db_test.go
@@ -1053,6 +1053,15 @@ func TestCopy(t *testing.T) {
 			err:     "kivik: invalid type chan int for options",
 		},
 		{
+			name:    "invalid full commit type",
+			db:      &db{},
+			source:  "foo",
+			target:  "bar",
+			options: map[string]interface{}{OptionFullCommit: 123},
+			status:  kivik.StatusBadRequest,
+			err:     "kivik: option 'full-commit' must be bool, not int",
+		},
+		{
 			name:   "create 1.6.1",
 			source: "foo",
 			target: "bar",

--- a/db_test.go
+++ b/db_test.go
@@ -1077,7 +1077,7 @@ func TestCopy(t *testing.T) {
 			rev: "1-f81c8a795b0c6f9e9f699f64c6b82256",
 		},
 		{
-			name:   "force commit 1.6.1",
+			name:   "full commit 1.6.1",
 			source: "foo",
 			target: "bar",
 			options: map[string]interface{}{

--- a/db_test.go
+++ b/db_test.go
@@ -1059,7 +1059,7 @@ func TestCopy(t *testing.T) {
 			target:  "bar",
 			options: map[string]interface{}{OptionFullCommit: 123},
 			status:  kivik.StatusBadRequest,
-			err:     "kivik: option 'full-commit' must be bool, not int",
+			err:     "kivik: option 'X-Couch-Full-Commit' must be bool, not int",
 		},
 		{
 			name:   "create 1.6.1",

--- a/options.go
+++ b/options.go
@@ -5,8 +5,7 @@ import (
 	"github.com/flimzy/kivik/errors"
 )
 
-func fullCommit(opts map[string]interface{}) (bool, error) {
-	var fullCommit bool
+func fullCommit(fullCommit bool, opts map[string]interface{}) (bool, error) {
 	for _, key := range []string{optionForceCommit, OptionFullCommit} {
 		fc, ok := opts[key]
 		if ok {

--- a/options.go
+++ b/options.go
@@ -5,15 +5,18 @@ import (
 	"github.com/flimzy/kivik/errors"
 )
 
-func forceCommit(opts map[string]interface{}) (bool, error) {
-	fc, ok := opts[OptionFullCommit]
-	if !ok {
-		return false, nil
+func fullCommit(opts map[string]interface{}) (bool, error) {
+	var fullCommit bool
+	for _, key := range []string{optionForceCommit, OptionFullCommit} {
+		fc, ok := opts[key]
+		if ok {
+			fcBool, ok := fc.(bool)
+			if !ok {
+				return false, errors.Statusf(kivik.StatusBadRequest, "kivik: option '%s' must be bool, not %T", key, fc)
+			}
+			fullCommit = fcBool
+			delete(opts, key)
+		}
 	}
-	fcBool, ok := fc.(bool)
-	if !ok {
-		return false, errors.Statusf(kivik.StatusBadRequest, "kivik: option '%s' must be bool, not %T", OptionFullCommit, fc)
-	}
-	delete(opts, OptionFullCommit)
-	return fcBool, nil
+	return fullCommit, nil
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,59 @@
+package couchdb
+
+import (
+	"testing"
+
+	"github.com/flimzy/testy"
+)
+
+func TestFullCommit(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected bool
+		err      string
+	}{
+		{
+			name:     "legacy",
+			input:    map[string]interface{}{"force_commit": true},
+			expected: true,
+		},
+		{
+			name:  "legacy error",
+			input: map[string]interface{}{"force_commit": 123},
+			err:   "kivik: option 'force_commit' must be bool, not int",
+		},
+		{
+			name:     "new",
+			input:    map[string]interface{}{"full-commit": true},
+			expected: true,
+		},
+		{
+			name:  "new error",
+			input: map[string]interface{}{"full-commit": 123},
+			err:   "kivik: option 'full-commit' must be bool, not int",
+		},
+		{
+			name: "new priority over old",
+			input: map[string]interface{}{
+				"full-commit":  false,
+				"force_commit": true,
+			},
+			expected: false,
+		},
+		{
+			name:     "none",
+			input:    nil,
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := fullCommit(test.input)
+			testy.Error(t, test.err, err)
+			if result != test.expected {
+				t.Errorf("Unexpected result: %v", result)
+			}
+		})
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -18,31 +18,31 @@ func TestFullCommit(t *testing.T) {
 	}{
 		{
 			name:     "legacy",
-			input:    map[string]interface{}{"force_commit": true},
+			input:    map[string]interface{}{optionForceCommit: true},
 			expected: true,
 		},
 		{
 			name:   "legacy error",
-			input:  map[string]interface{}{"force_commit": 123},
+			input:  map[string]interface{}{optionForceCommit: 123},
 			status: kivik.StatusBadRequest,
 			err:    "kivik: option 'force_commit' must be bool, not int",
 		},
 		{
 			name:     "new",
-			input:    map[string]interface{}{"full-commit": true},
+			input:    map[string]interface{}{OptionFullCommit: true},
 			expected: true,
 		},
 		{
 			name:   "new error",
-			input:  map[string]interface{}{"full-commit": 123},
+			input:  map[string]interface{}{OptionFullCommit: 123},
 			status: kivik.StatusBadRequest,
-			err:    "kivik: option 'full-commit' must be bool, not int",
+			err:    "kivik: option 'X-Couch-Full-Commit' must be bool, not int",
 		},
 		{
 			name: "new priority over old",
 			input: map[string]interface{}{
-				"full-commit":  false,
-				"force_commit": true,
+				OptionFullCommit:  false,
+				optionForceCommit: true,
 			},
 			expected: false,
 		},
@@ -60,13 +60,13 @@ func TestFullCommit(t *testing.T) {
 		{
 			name:     "override default",
 			def:      true,
-			input:    map[string]interface{}{"full-commit": false},
+			input:    map[string]interface{}{OptionFullCommit: false},
 			expected: false,
 		},
 		{
 			name:     "default and option agree",
 			def:      true,
-			input:    map[string]interface{}{"full-commit": true},
+			input:    map[string]interface{}{OptionFullCommit: true},
 			expected: true,
 		},
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -3,14 +3,17 @@ package couchdb
 import (
 	"testing"
 
+	"github.com/flimzy/kivik"
 	"github.com/flimzy/testy"
 )
 
 func TestFullCommit(t *testing.T) {
 	tests := []struct {
 		name     string
+		def      bool
 		input    map[string]interface{}
 		expected bool
+		status   int
 		err      string
 	}{
 		{
@@ -19,9 +22,10 @@ func TestFullCommit(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:  "legacy error",
-			input: map[string]interface{}{"force_commit": 123},
-			err:   "kivik: option 'force_commit' must be bool, not int",
+			name:   "legacy error",
+			input:  map[string]interface{}{"force_commit": 123},
+			status: kivik.StatusBadRequest,
+			err:    "kivik: option 'force_commit' must be bool, not int",
 		},
 		{
 			name:     "new",
@@ -29,9 +33,10 @@ func TestFullCommit(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:  "new error",
-			input: map[string]interface{}{"full-commit": 123},
-			err:   "kivik: option 'full-commit' must be bool, not int",
+			name:   "new error",
+			input:  map[string]interface{}{"full-commit": 123},
+			status: kivik.StatusBadRequest,
+			err:    "kivik: option 'full-commit' must be bool, not int",
 		},
 		{
 			name: "new priority over old",
@@ -46,11 +51,29 @@ func TestFullCommit(t *testing.T) {
 			input:    nil,
 			expected: false,
 		},
+		{
+			name:     "true default, no option",
+			def:      true,
+			input:    nil,
+			expected: true,
+		},
+		{
+			name:     "override default",
+			def:      true,
+			input:    map[string]interface{}{"full-commit": false},
+			expected: false,
+		},
+		{
+			name:     "default and option agree",
+			def:      true,
+			input:    map[string]interface{}{"full-commit": true},
+			expected: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := fullCommit(test.input)
-			testy.Error(t, test.err, err)
+			result, err := fullCommit(test.def, test.input)
+			testy.StatusError(t, test.err, test.status, err)
 			if result != test.expected {
 				t.Errorf("Unexpected result: %v", result)
 			}

--- a/replication.go
+++ b/replication.go
@@ -83,7 +83,7 @@ var _ driver.Replication = &replication{}
 
 func (c *client) fetchReplication(ctx context.Context, docID string) *replication {
 	rep := c.newReplication(docID)
-	rep.db = &db{client: c, dbName: "_replicator", forceCommit: true}
+	rep.db = &db{client: c, dbName: "_replicator", fullCommit: true}
 	// Do an update to get the initial state, but don't fail if there's an error
 	// at this stage, because we successfully created the replication doc.
 	_ = rep.updateMain(ctx)


### PR DESCRIPTION
... For consistency with CouchDB terminology.

And retain the old 'force_commit' option for backward compatibility.