### PR TITLE
Query post

### DIFF
--- a/db.go
+++ b/db.go
@@ -64,11 +64,22 @@ func optionsToParams(opts ...map[string]interface{}) (url.Values, error) {
 
 // rowsQuery performs a query that returns a rows iterator.
 func (d *db) rowsQuery(ctx context.Context, path string, opts map[string]interface{}) (driver.Rows, error) {
+	// Queries with large key options can be converted to POST.
+	method := kivik.MethodGet
+	var dropts *chttp.Options
+	if keys, ok := opts["keys"].(string); ok && len(keys) > 1024 {
+		method = kivik.MethodPost
+		dropts = &chttp.Options{
+			Body: ioutil.NopCloser(strings.NewReader(fmt.Sprintf(`{"keys":%s}`, keys))),
+		}
+		delete(opts, "keys")
+
+	}
 	options, err := optionsToParams(opts)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := d.Client.DoReq(ctx, kivik.MethodGet, d.path(path, options), nil)
+	resp, err := d.Client.DoReq(ctx, method, d.path(path, options), dropts)
 	if err != nil {
 		return nil, err
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -1271,7 +1271,7 @@ func TestRowsQueryKeys(t *testing.T) {
 				}
 				keys := string(req.URL.Query().Get("keys"))
 				if keys != `["one","two"]` {
-					return nil, errors.New(fmt.Sprintf("wrong keys: '%s'", keys))
+					return nil, fmt.Errorf("wrong keys: '%s'", keys)
 				}
 				resp := &http.Response{
 					StatusCode: kivik.StatusOK,


### PR DESCRIPTION
A long keys option can result in a large URL that errors out with Bad Request. CouchDB allows Query keys to be passed in the body of a POST to handle many keys. http://docs.couchdb.org/en/2.1.1/api/ddoc/views.html#post--db-_design-ddoc-_view-view