### PR TITLE
Add chttp.NewWithClient() method to properly inject a custom HTTP client

### DIFF
--- a/chttp/chttp.go
+++ b/chttp/chttp.go
@@ -50,6 +50,12 @@ type Client struct {
 // use HTTP BasicAuth or some other authentication mechanism, do not specify
 // credentials in the URL, and instead call the Auth() method later.
 func New(dsn string) (*Client, error) {
+	return NewWithClient(&http.Client{}, dsn)
+}
+
+// NewWithClient works the same as New(), but allows providing a custom
+// *http.Client for all network connections.
+func NewWithClient(client *http.Client, dsn string) (*Client, error) {
 	dsnURL, err := parseDSN(dsn)
 	if err != nil {
 		return nil, err
@@ -57,7 +63,7 @@ func New(dsn string) (*Client, error) {
 	user := dsnURL.User
 	dsnURL.User = nil
 	c := &Client{
-		Client: &http.Client{},
+		Client: client,
 		dsn:    dsnURL,
 		rawDSN: dsn,
 	}

--- a/couchdb.go
+++ b/couchdb.go
@@ -51,12 +51,13 @@ var _ driver.DBUpdater = &client{}
 // different auth mechanism, do not specify credentials here, and instead call
 // Authenticate() later.
 func (d *Couch) NewClient(dsn string) (driver.Client, error) {
-	chttpClient, err := chttp.New(dsn)
+	httpClient := d.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	chttpClient, err := chttp.NewWithClient(httpClient, dsn)
 	if err != nil {
 		return nil, err
-	}
-	if d.HTTPClient != nil {
-		chttpClient.Client = d.HTTPClient
 	}
 	chttpClient.UserAgents = []string{
 		fmt.Sprintf("Kivik/%s", kivik.KivikVersion),


### PR DESCRIPTION
Improves on #153 