### PR TITLE
Changes paginated "normal" feed support

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -76,7 +76,7 @@ func (r *changesRows) Next(row *driver.Change) error {
 	return nil
 }
 
-func (r *changesRows) LastSeq() string {
+func (r *changesRows) LastSeq() driver.SequenceID {
 	return ""
 }
 

--- a/changes.go
+++ b/changes.go
@@ -13,10 +13,13 @@ import (
 
 // Changes returns the changes stream for the database.
 func (d *db) Changes(ctx context.Context, opts map[string]interface{}) (driver.Changes, error) {
-	overrideOpts := map[string]interface{}{
-		"feed":      "continuous",
-		"since":     "now",
-		"heartbeat": 6000,
+	var overrideOpts map[string]interface{}
+	if opts["feed"] != "normal" {
+		overrideOpts = map[string]interface{}{
+			"feed":      "continuous",
+			"since":     "now",
+			"heartbeat": 6000,
+		}
 	}
 	query, err := optionsToParams(opts, overrideOpts)
 	if err != nil {
@@ -31,6 +34,9 @@ func (d *db) Changes(ctx context.Context, opts map[string]interface{}) (driver.C
 	}
 	if err = chttp.ResponseError(resp); err != nil {
 		return nil, err
+	}
+	if overrideOpts == nil {
+		return newChangesNormal(resp.Body), nil
 	}
 	return newChangesRows(resp.Body), nil
 }

--- a/db.go
+++ b/db.go
@@ -69,18 +69,19 @@ func optionsToParams(opts ...map[string]interface{}) (url.Values, error) {
 
 // rowsQuery performs a query that returns a rows iterator.
 func (d *db) rowsQuery(ctx context.Context, path string, opts map[string]interface{}) (driver.Rows, error) {
+	keys := opts["keys"]
+	delete(opts, "keys")
 	query, err := optionsToParams(opts)
 	if err != nil {
 		return nil, err
 	}
 	options := &chttp.Options{Query: query}
 	method := kivik.MethodGet
-	if keys, ok := query["keys"]; ok {
+	if keys != nil {
 		method = kivik.MethodPost
-		options.Body = chttp.EncodeBody(map[string][]string{
+		options.Body = chttp.EncodeBody(map[string]interface{}{
 			"keys": keys,
 		})
-		delete(query, "keys")
 	}
 	resp, err := d.Client.DoReq(ctx, method, d.path(path), options)
 	if err != nil {

--- a/rows.go
+++ b/rows.go
@@ -92,8 +92,8 @@ func (r *rows) Bookmark() string {
 	return r.bookmark
 }
 
-func (r *rows) LastSeq() string {
-	return r.lastSeq
+func (r *rows) LastSeq() driver.SequenceID {
+	return driver.SequenceID(r.lastSeq)
 }
 
 func (r *rows) UpdateSeq() string {


### PR DESCRIPTION
This PR and a related PR on kivik extend the Changes and rows api to support a "normal" Changes feed. The normal changes response looks very similar to a bulk rows response, except each row is a Change.