### PR TITLE
Add ProxyAuth Authenticator to support OAuth2 style authorization

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -79,6 +79,14 @@ func CookieAuth(user, password string) Authenticator {
 	})
 }
 
+// ProxyAuth provides support for Proxy authentication.
+func ProxyAuth(user, secret string, roles []string) Authenticator {
+	auth := chttp.ProxyAuth{Username: user, Secret: secret, Roles: roles}
+	return authFunc(func(ctx context.Context, c *client) error {
+		return auth.Authenticate(c.Client)
+	})
+}
+
 type rawCookie struct {
 	cookie *http.Cookie
 	next   http.RoundTripper

--- a/auth.go
+++ b/auth.go
@@ -80,8 +80,8 @@ func CookieAuth(user, password string) Authenticator {
 }
 
 // ProxyAuth provides support for Proxy authentication.
-func ProxyAuth(user, secret string, roles []string) Authenticator {
-	auth := chttp.ProxyAuth{Username: user, Secret: secret, Roles: roles}
+func ProxyAuth(user, secret string, roles []string, headers map[string]string) Authenticator {
+	auth := chttp.ProxyAuth{Username: user, Secret: secret, Roles: roles, Headers: headers}
 	return authFunc(func(ctx context.Context, c *client) error {
 		return auth.Authenticate(c.Client)
 	})

--- a/auth_test.go
+++ b/auth_test.go
@@ -153,14 +153,14 @@ func TestAuthentication(t *testing.T) {
 				if h := r.Header.Get("X-Auth-CouchDB-Roles"); h != "users,admins" {
 					t.Errorf("Unexpected X-Auth-CouchDB-Roles header: %s\n", h)
 				}
-				if h := r.Header.Get("X-Auth-CouchDB-Token"); h != "adedb8d002eb53a52faba80e82cb1fc6d57bca74" {
-					t.Errorf("Unexpected X-Auth-CouchDB-Token header: %s\n", h)
+				if h := r.Header.Get("moo"); h != "adedb8d002eb53a52faba80e82cb1fc6d57bca74" {
+					t.Errorf("Token header override failed: %s instead of 'moo'\n", h)
 				}
 				w.WriteHeader(200)
 				_, _ = w.Write([]byte(`{}`))
 			})
 		},
-		auther: ProxyAuth("bob", "abc123", []string{"users", "admins"}),
+		auther: ProxyAuth("bob", "abc123", []string{"users", "admins"}, map[string]string{"token": "moo"}),
 	})
 	tests.Add("SetCookie", tst{
 		handler: func(t *testing.T) http.Handler {

--- a/auth_test.go
+++ b/auth_test.go
@@ -144,6 +144,24 @@ func TestAuthentication(t *testing.T) {
 		},
 		auther: CookieAuth("bob", "abc123"),
 	})
+	tests.Add("ProxyAuth", tst{
+		handler: func(t *testing.T) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if h := r.Header.Get("X-Auth-CouchDB-UserName"); h != "bob" {
+					t.Errorf("Unexpected X-Auth-CouchDB-UserName header: %s\n", h)
+				}
+				if h := r.Header.Get("X-Auth-CouchDB-Roles"); h != "users,admins" {
+					t.Errorf("Unexpected X-Auth-CouchDB-Roles header: %s\n", h)
+				}
+				if h := r.Header.Get("X-Auth-CouchDB-Token"); h != "adedb8d002eb53a52faba80e82cb1fc6d57bca74" {
+					t.Errorf("Unexpected X-Auth-CouchDB-Token header: %s\n", h)
+				}
+				w.WriteHeader(200)
+				_, _ = w.Write([]byte(`{}`))
+			})
+		},
+		auther: ProxyAuth("bob", "abc123", []string{"users", "admins"}),
+	})
 	tests.Add("SetCookie", tst{
 		handler: func(t *testing.T) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/chttp/proxyauth.go
+++ b/chttp/proxyauth.go
@@ -1,0 +1,49 @@
+package chttp
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"net/http"
+	"strings"
+)
+
+type ProxyAuth struct {
+	Username string
+	Secret   string
+	Roles    []string
+
+	transport http.RoundTripper
+}
+
+var _ Authenticator = &ProxyAuth{}
+
+func (a *ProxyAuth) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Convert roles slice to comma separated values
+	rolesCsv := strings.Join(a.Roles[:], ",")
+
+	// Generate auth token
+	// https://docs.couchdb.org/en/stable/config/auth.html#couch_httpd_auth/x_auth_token
+	h := hmac.New(sha1.New, []byte(a.Secret))
+	_, err := h.Write([]byte(a.Username))
+	if err != nil {
+		return nil, err
+	}
+	token := hex.EncodeToString(h.Sum(nil))
+
+	// Add headers to request
+	req.Header.Set("X-Auth-CouchDB-UserName", a.Username)
+	req.Header.Set("X-Auth-CouchDB-Roles", rolesCsv)
+	req.Header.Set("X-Auth-CouchDB-Token", token)
+
+	return a.transport.RoundTrip(req)
+}
+
+func (a *ProxyAuth) Authenticate(c *Client) error {
+	a.transport = c.Transport
+	if a.transport == nil {
+		a.transport = http.DefaultTransport
+	}
+	c.Transport = a
+	return nil
+}

--- a/chttp/proxyauth.go
+++ b/chttp/proxyauth.go
@@ -12,6 +12,7 @@ type ProxyAuth struct {
 	Username string
 	Secret   string
 	Roles    []string
+	Headers  map[string]string
 
 	transport http.RoundTripper
 }
@@ -19,22 +20,45 @@ type ProxyAuth struct {
 var _ Authenticator = &ProxyAuth{}
 
 func (a *ProxyAuth) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Default header names
+	tokenHeaderName := "X-Auth-CouchDB-Token"
+	usernameHeaderName := "X-Auth-CouchDB-UserName"
+	rolesHeaderName := "X-Auth-CouchDB-Roles"
+
+	// Override the token header if specified
+	if val, ok := a.Headers["token"]; ok {
+		tokenHeaderName = val
+	}
+
+	// Override the username header if specified
+	if val, ok := a.Headers["username"]; ok {
+		usernameHeaderName = val
+	}
+
+	// Override the roles header if specified
+	if val, ok := a.Headers["roles"]; ok {
+		rolesHeaderName = val
+	}
+
 	// Convert roles slice to comma separated values
 	rolesCsv := strings.Join(a.Roles[:], ",")
 
-	// Generate auth token
-	// https://docs.couchdb.org/en/stable/config/auth.html#couch_httpd_auth/x_auth_token
-	h := hmac.New(sha1.New, []byte(a.Secret))
-	_, err := h.Write([]byte(a.Username))
-	if err != nil {
-		return nil, err
+	// If the secret is an empty string, do not calculate the token
+	if a.Secret != "" {
+		// Generate auth token
+		// https://docs.couchdb.org/en/stable/config/auth.html#couch_httpd_auth/x_auth_token
+		h := hmac.New(sha1.New, []byte(a.Secret))
+		_, err := h.Write([]byte(a.Username))
+		if err != nil {
+			return nil, err
+		}
+		token := hex.EncodeToString(h.Sum(nil))
+		req.Header.Set(tokenHeaderName, token)
 	}
-	token := hex.EncodeToString(h.Sum(nil))
 
 	// Add headers to request
-	req.Header.Set("X-Auth-CouchDB-UserName", a.Username)
-	req.Header.Set("X-Auth-CouchDB-Roles", rolesCsv)
-	req.Header.Set("X-Auth-CouchDB-Token", token)
+	req.Header.Set(usernameHeaderName, a.Username)
+	req.Header.Set(rolesHeaderName, rolesCsv)
 
 	return a.transport.RoundTrip(req)
 }

--- a/chttp/proxyauth_test.go
+++ b/chttp/proxyauth_test.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	rolesTest    = "users,admins"
+	secretTest   = "abc123"
 	tokenTest    = "adedb8d002eb53a52faba80e82cb1fc6d57bca74"
 	usernameTest = "bob"
 )
@@ -28,7 +29,7 @@ func TestProxyAuthRoundTrip(t *testing.T) {
 			req:  httptest.NewRequest("GET", "/", nil),
 			auth: &ProxyAuth{
 				Username: usernameTest,
-				Secret:   "abc123",
+				Secret:   secretTest,
 				Roles:    []string{"users", "admins"},
 				Headers:  map[string]string{},
 				transport: customTransport(func(req *http.Request) (*http.Response, error) {
@@ -76,7 +77,7 @@ func TestProxyAuthRoundTrip(t *testing.T) {
 			req:  httptest.NewRequest("GET", "/", nil),
 			auth: &ProxyAuth{
 				Username: usernameTest,
-				Secret:   "abc123",
+				Secret:   secretTest,
 				Roles:    []string{"users", "admins"},
 				Headers:  map[string]string{"token": "moo", "username": "cow", "roles": "bovine"},
 				transport: customTransport(func(req *http.Request) (*http.Response, error) {
@@ -125,7 +126,7 @@ func TestProxyAuthRoundTrip(t *testing.T) {
 				name: "default transport",
 				auth: &ProxyAuth{
 					Username:  usernameTest,
-					Secret:    "abc123",
+					Secret:    secretTest,
 					Roles:     []string{"users", "admins"},
 					Headers:   map[string]string{},
 					transport: http.DefaultTransport,

--- a/chttp/proxyauth_test.go
+++ b/chttp/proxyauth_test.go
@@ -8,6 +8,12 @@ import (
 	"github.com/flimzy/diff"
 )
 
+const (
+	rolesTest    = "users,admins"
+	tokenTest    = "adedb8d002eb53a52faba80e82cb1fc6d57bca74"
+	usernameTest = "bob"
+)
+
 func TestProxyAuthRoundTrip(t *testing.T) {
 	type rtTest struct {
 		name     string
@@ -21,23 +27,23 @@ func TestProxyAuthRoundTrip(t *testing.T) {
 			name: "Provided transport",
 			req:  httptest.NewRequest("GET", "/", nil),
 			auth: &ProxyAuth{
-				Username: "bob",
+				Username: usernameTest,
 				Secret:   "abc123",
 				Roles:    []string{"users", "admins"},
 				Headers:  map[string]string{},
 				transport: customTransport(func(req *http.Request) (*http.Response, error) {
 					username := req.Header.Get("X-Auth-CouchDB-UserName")
-					if username != "bob" {
+					if username != usernameTest {
 						t.Errorf("Unexpected X-Auth-CouchDB-UserName value: %s", username)
 					}
 
 					roles := req.Header.Get("X-Auth-CouchDB-Roles")
-					if roles != "users,admins" {
+					if roles != rolesTest {
 						t.Errorf("Unexpected X-Auth-CouchDB-Roles value: %s", roles)
 					}
 
 					token := req.Header.Get("X-Auth-CouchDB-Token")
-					if token != "adedb8d002eb53a52faba80e82cb1fc6d57bca74" {
+					if token != tokenTest {
 						t.Errorf("Unexpected X-Auth-CouchDB-Token value: %s", token)
 					}
 
@@ -50,7 +56,7 @@ func TestProxyAuthRoundTrip(t *testing.T) {
 			name: "Secret is an empty string",
 			req:  httptest.NewRequest("GET", "/", nil),
 			auth: &ProxyAuth{
-				Username: "bob",
+				Username: usernameTest,
 				Secret:   "",
 				Roles:    []string{"users", "admins"},
 				Headers:  map[string]string{},
@@ -69,23 +75,23 @@ func TestProxyAuthRoundTrip(t *testing.T) {
 			name: "Overridden header names",
 			req:  httptest.NewRequest("GET", "/", nil),
 			auth: &ProxyAuth{
-				Username: "bob",
+				Username: usernameTest,
 				Secret:   "abc123",
 				Roles:    []string{"users", "admins"},
 				Headers:  map[string]string{"token": "moo", "username": "cow", "roles": "bovine"},
 				transport: customTransport(func(req *http.Request) (*http.Response, error) {
 					username := req.Header.Get("cow")
-					if username != "bob" {
+					if username != usernameTest {
 						t.Error("Username header override failed")
 					}
 
 					roles := req.Header.Get("bovine")
-					if roles != "users,admins" {
+					if roles != rolesTest {
 						t.Error("Roles header override failed")
 					}
 
 					token := req.Header.Get("moo")
-					if token != "adedb8d002eb53a52faba80e82cb1fc6d57bca74" {
+					if token != tokenTest {
 						t.Error("Token header override failed")
 					}
 
@@ -97,17 +103,17 @@ func TestProxyAuthRoundTrip(t *testing.T) {
 		func() rtTest {
 			h := func(w http.ResponseWriter, r *http.Request) {
 				username := r.Header.Get("X-Auth-CouchDB-UserName")
-				if username != "bob" {
+				if username != usernameTest {
 					t.Errorf("Unexpected X-Auth-CouchDB-UserName value: %s", username)
 				}
 
 				roles := r.Header.Get("X-Auth-CouchDB-Roles")
-				if roles != "users,admins" {
+				if roles != rolesTest {
 					t.Errorf("Unexpected X-Auth-CouchDB-Roles value: %s", roles)
 				}
 
 				token := r.Header.Get("X-Auth-CouchDB-Token")
-				if token != "adedb8d002eb53a52faba80e82cb1fc6d57bca74" {
+				if token != tokenTest {
 					t.Errorf("Unexpected X-Auth-CouchDB-Token value: %s", token)
 				}
 
@@ -118,7 +124,7 @@ func TestProxyAuthRoundTrip(t *testing.T) {
 			return rtTest{
 				name: "default transport",
 				auth: &ProxyAuth{
-					Username:  "bob",
+					Username:  usernameTest,
 					Secret:    "abc123",
 					Roles:     []string{"users", "admins"},
 					Headers:   map[string]string{},

--- a/chttp/proxyauth_test.go
+++ b/chttp/proxyauth_test.go
@@ -1,0 +1,107 @@
+package chttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flimzy/diff"
+)
+
+func TestProxyAuthRoundTrip(t *testing.T) {
+	type rtTest struct {
+		name     string
+		auth     *ProxyAuth
+		req      *http.Request
+		expected *http.Response
+		cleanup  func()
+	}
+	tests := []rtTest{
+		{
+			name: "Provided transport",
+			req:  httptest.NewRequest("GET", "/", nil),
+			auth: &ProxyAuth{
+				Username: "bob",
+				Secret:   "abc123",
+				Roles:    []string{"users", "admins"},
+				transport: customTransport(func(req *http.Request) (*http.Response, error) {
+					username := req.Header.Get("X-Auth-CouchDB-UserName")
+					if username != "bob" {
+						t.Errorf("Unexpected X-Auth-CouchDB-UserName value: %s", username)
+					}
+
+					roles := req.Header.Get("X-Auth-CouchDB-Roles")
+					if roles != "users,admins" {
+						t.Errorf("Unexpected X-Auth-CouchDB-Roles value: %s", roles)
+					}
+
+					token := req.Header.Get("X-Auth-CouchDB-Token")
+					if token != "adedb8d002eb53a52faba80e82cb1fc6d57bca74" {
+						t.Errorf("Unexpected X-Auth-CouchDB-Token value: %s", token)
+					}
+
+					return &http.Response{StatusCode: 200}, nil
+				}),
+			},
+			expected: &http.Response{StatusCode: 200},
+		},
+		func() rtTest {
+			h := func(w http.ResponseWriter, r *http.Request) {
+				username := r.Header.Get("X-Auth-CouchDB-UserName")
+				if username != "bob" {
+					t.Errorf("Unexpected X-Auth-CouchDB-UserName value: %s", username)
+				}
+
+				roles := r.Header.Get("X-Auth-CouchDB-Roles")
+				if roles != "users,admins" {
+					t.Errorf("Unexpected X-Auth-CouchDB-Roles value: %s", roles)
+				}
+
+				token := r.Header.Get("X-Auth-CouchDB-Token")
+				if token != "adedb8d002eb53a52faba80e82cb1fc6d57bca74" {
+					t.Errorf("Unexpected X-Auth-CouchDB-Token value: %s", token)
+				}
+
+				w.Header().Set("Date", "Wed, 01 Nov 2017 19:32:41 GMT")
+				w.Header().Set("Content-Type", "application/json")
+			}
+			s := httptest.NewServer(http.HandlerFunc(h))
+			return rtTest{
+				name: "default transport",
+				auth: &ProxyAuth{
+					Username:  "bob",
+					Secret:    "abc123",
+					Roles:     []string{"users", "admins"},
+					transport: http.DefaultTransport,
+				},
+				req: httptest.NewRequest("GET", s.URL, nil),
+				expected: &http.Response{
+					Status:     "200 OK",
+					StatusCode: 200,
+					Proto:      "HTTP/1.1",
+					ProtoMajor: 1,
+					ProtoMinor: 1,
+					Header: http.Header{
+						"Content-Length": {"0"},
+						"Content-Type":   {"application/json"},
+						"Date":           {"Wed, 01 Nov 2017 19:32:41 GMT"},
+					},
+				},
+				cleanup: func() { s.Close() },
+			}
+		}(),
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := test.auth.RoundTrip(test.req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			res.Body = nil
+			res.Request = nil
+			if d := diff.Interface(test.expected, res); d != nil {
+				t.Error(d)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves #181 by implementing Proxy Authentication (https://docs.couchdb.org/en/stable/api/server/authn.html#proxy-authentication)

A list of roles as well as a username and HMAC secret are passed to the new authenticator. A token is generated from the secret and username using SHA1 as specified in the Couch docs. The roles are turned into a list of comma separated values. These values are then added to the appropriate request headers:

 * `X-Auth-CouchDB-UserName`
 * `X-Auth-CouchDB-Roles`
 * `X-Auth-CouchDB-Token`

chttp test:
```
0 ✓  chttp [add_proxyauth]$ go test -run TestProxyAuthRoundTrip
PASS
ok  	github.com/mmarod/couchdb/chttp	0.014s
```

auth test:
```
0 ✓  couchdb [add_proxyauth]$ go test -run TestAuthentication
PASS
ok  	github.com/mmarod/couchdb	0.016s
```