### PR TITLE
Make many requests more re-tryable

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -48,7 +48,7 @@ func (d *db) PutAttachment(ctx context.Context, docID, rev string, att *driver.A
 		FullCommit:  fullCommit,
 		Query:       query,
 	}
-	_, err = d.Client.DoJSON(ctx, kivik.MethodPut, d.path(chttp.EncodeDocID(docID)+"/"+att.Filename), opts, &response)
+	_, err = d.Client.DoJSON(ctx, http.MethodPut, d.path(chttp.EncodeDocID(docID)+"/"+att.Filename), opts, &response)
 	if err != nil {
 		return "", err
 	}
@@ -56,7 +56,7 @@ func (d *db) PutAttachment(ctx context.Context, docID, rev string, att *driver.A
 }
 
 func (d *db) GetAttachmentMeta(ctx context.Context, docID, filename string, options map[string]interface{}) (*driver.Attachment, error) {
-	resp, err := d.fetchAttachment(ctx, kivik.MethodHead, docID, filename, options)
+	resp, err := d.fetchAttachment(ctx, http.MethodHead, docID, filename, options)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (d *db) GetAttachmentMeta(ctx context.Context, docID, filename string, opti
 }
 
 func (d *db) GetAttachment(ctx context.Context, docID, filename string, options map[string]interface{}) (*driver.Attachment, error) {
-	resp, err := d.fetchAttachment(ctx, kivik.MethodGet, docID, filename, options)
+	resp, err := d.fetchAttachment(ctx, http.MethodGet, docID, filename, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func (d *db) DeleteAttachment(ctx context.Context, docID, rev, filename string, 
 		FullCommit: fullCommit,
 		Query:      query,
 	}
-	_, err = d.Client.DoJSON(ctx, kivik.MethodDelete, d.path(chttp.EncodeDocID(docID)+"/"+filename), opts, &response)
+	_, err = d.Client.DoJSON(ctx, http.MethodDelete, d.path(chttp.EncodeDocID(docID)+"/"+filename), opts, &response)
 	if err != nil {
 		return "", err
 	}

--- a/bulk.go
+++ b/bulk.go
@@ -77,7 +77,7 @@ func (d *db) BulkDocs(ctx context.Context, docs []interface{}, options map[strin
 	}
 	options["docs"] = docs
 	opts := &chttp.Options{
-		Body:       chttp.EncodeBody(options),
+		GetBody:    chttp.BodyEncoder(options),
 		FullCommit: fullCommit,
 	}
 	resp, err := d.Client.DoReq(ctx, http.MethodPost, d.path("_bulk_docs"), opts)

--- a/bulk.go
+++ b/bulk.go
@@ -80,7 +80,7 @@ func (d *db) BulkDocs(ctx context.Context, docs []interface{}, options map[strin
 		Body:       chttp.EncodeBody(options),
 		FullCommit: fullCommit,
 	}
-	resp, err := d.Client.DoReq(ctx, kivik.MethodPost, d.path("_bulk_docs"), opts)
+	resp, err := d.Client.DoReq(ctx, http.MethodPost, d.path("_bulk_docs"), opts)
 	if err != nil {
 		return nil, err
 	}

--- a/bulkget.go
+++ b/bulkget.go
@@ -18,6 +18,9 @@ func (d *db) BulkGet(ctx context.Context, docs []driver.BulkGetReference, opts m
 	options := &chttp.Options{
 		Query: query,
 		Body:  chttp.EncodeBody(docs),
+		Header: http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		},
 	}
 	resp, err := d.Client.DoReq(ctx, http.MethodPost, d.path("_bulk_get"), options)
 	if err != nil {

--- a/bulkget.go
+++ b/bulkget.go
@@ -16,8 +16,8 @@ func (d *db) BulkGet(ctx context.Context, docs []driver.BulkGetReference, opts m
 		return nil, err
 	}
 	options := &chttp.Options{
-		Query: query,
-		Body:  chttp.EncodeBody(docs),
+		Query:   query,
+		GetBody: chttp.BodyEncoder(docs),
 		Header: http.Header{
 			chttp.HeaderIdempotencyKey: []string{},
 		},

--- a/changes.go
+++ b/changes.go
@@ -31,7 +31,7 @@ func (d *db) Changes(ctx context.Context, opts map[string]interface{}) (driver.C
 	options := &chttp.Options{
 		Query: query,
 	}
-	resp, err := d.Client.DoReq(ctx, kivik.MethodGet, d.path("_changes"), options)
+	resp, err := d.Client.DoReq(ctx, http.MethodGet, d.path("_changes"), options)
 	if err != nil {
 		return nil, err
 	}

--- a/chttp/constants.go
+++ b/chttp/constants.go
@@ -2,5 +2,6 @@ package chttp
 
 // Standard headers used by CouchDB.
 const (
-	HeaderDestination = "Destination"
+	HeaderDestination    = "Destination"
+	HeaderIdempotencyKey = "X-Idempotency-Key"
 )

--- a/chttp/cookieauth.go
+++ b/chttp/cookieauth.go
@@ -78,6 +78,9 @@ func (a *CookieAuth) authenticate(req *http.Request) error {
 	ctx = context.WithValue(ctx, authInProgress, true)
 	opts := &Options{
 		Body: EncodeBody(a),
+		Header: http.Header{
+			HeaderIdempotencyKey: []string{},
+		},
 	}
 	if _, err := a.client.DoError(ctx, http.MethodPost, "/_session", opts); err != nil {
 		return err

--- a/chttp/cookieauth.go
+++ b/chttp/cookieauth.go
@@ -77,7 +77,7 @@ func (a *CookieAuth) authenticate(req *http.Request) error {
 	}
 	ctx = context.WithValue(ctx, authInProgress, true)
 	opts := &Options{
-		Body: EncodeBody(a),
+		GetBody: BodyEncoder(a),
 		Header: http.Header{
 			HeaderIdempotencyKey: []string{},
 		},

--- a/chttp/cookieauth.go
+++ b/chttp/cookieauth.go
@@ -79,7 +79,7 @@ func (a *CookieAuth) authenticate(req *http.Request) error {
 	opts := &Options{
 		Body: EncodeBody(a),
 	}
-	if _, err := a.client.DoError(ctx, kivik.MethodPost, "/_session", opts); err != nil {
+	if _, err := a.client.DoError(ctx, http.MethodPost, "/_session", opts); err != nil {
 		return err
 	}
 	if c := a.Cookie(); c != nil {

--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ func (c *client) AllDBs(ctx context.Context, opts map[string]interface{}) ([]str
 		return nil, err
 	}
 	var allDBs []string
-	_, err = c.DoJSON(ctx, kivik.MethodGet, "/_all_dbs", &chttp.Options{Query: query}, &allDBs)
+	_, err = c.DoJSON(ctx, http.MethodGet, "/_all_dbs", &chttp.Options{Query: query}, &allDBs)
 	return allDBs, err
 }
 
@@ -26,7 +26,7 @@ func (c *client) DBExists(ctx context.Context, dbName string, _ map[string]inter
 	if dbName == "" {
 		return false, missingArg("dbName")
 	}
-	_, err := c.DoError(ctx, kivik.MethodHead, dbName, nil)
+	_, err := c.DoError(ctx, http.MethodHead, dbName, nil)
 	if kivik.StatusCode(err) == http.StatusNotFound {
 		return false, nil
 	}
@@ -41,7 +41,7 @@ func (c *client) CreateDB(ctx context.Context, dbName string, opts map[string]in
 	if err != nil {
 		return err
 	}
-	_, err = c.DoError(ctx, kivik.MethodPut, dbName, &chttp.Options{Query: query})
+	_, err = c.DoError(ctx, http.MethodPut, dbName, &chttp.Options{Query: query})
 	return err
 }
 
@@ -49,12 +49,12 @@ func (c *client) DestroyDB(ctx context.Context, dbName string, _ map[string]inte
 	if dbName == "" {
 		return missingArg("dbName")
 	}
-	_, err := c.DoError(ctx, kivik.MethodDelete, dbName, nil)
+	_, err := c.DoError(ctx, http.MethodDelete, dbName, nil)
 	return err
 }
 
 func (c *client) DBUpdates(ctx context.Context) (updates driver.DBUpdates, err error) {
-	resp, err := c.DoReq(ctx, kivik.MethodGet, "/_db_updates?feed=continuous&since=now", nil)
+	resp, err := c.DoReq(ctx, http.MethodGet, "/_db_updates?feed=continuous&since=now", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (u *couchUpdates) Next(update *driver.DBUpdate) error {
 // if a 400 (Bad Request) is returned, and the Server: header indicates a server
 // version prior to 2.x.
 func (c *client) Ping(ctx context.Context) (bool, error) {
-	resp, err := c.DoError(ctx, kivik.MethodHead, "/_up", nil)
+	resp, err := c.DoError(ctx, http.MethodHead, "/_up", nil)
 	if kivik.StatusCode(err) == http.StatusBadRequest {
 		return strings.HasPrefix(resp.Header.Get("Server"), "CouchDB/1."), nil
 	}

--- a/db.go
+++ b/db.go
@@ -85,6 +85,9 @@ func (d *db) rowsQuery(ctx context.Context, path string, opts map[string]interfa
 		options.Body = chttp.EncodeBody(map[string]interface{}{
 			"keys": keys,
 		})
+		options.Header = http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		}
 	}
 	resp, err := d.Client.DoReq(ctx, method, d.path(path), options)
 	if err != nil {
@@ -728,12 +731,22 @@ func (d *db) Delete(ctx context.Context, docID, rev string, options map[string]i
 }
 
 func (d *db) Flush(ctx context.Context) error {
-	_, err := d.Client.DoError(ctx, http.MethodPost, d.path("/_ensure_full_commit"), nil)
+	opts := &chttp.Options{
+		Header: http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		},
+	}
+	_, err := d.Client.DoError(ctx, http.MethodPost, d.path("/_ensure_full_commit"), opts)
 	return err
 }
 
 func (d *db) Compact(ctx context.Context) error {
-	res, err := d.Client.DoReq(ctx, http.MethodPost, d.path("/_compact"), nil)
+	opts := &chttp.Options{
+		Header: http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		},
+	}
+	res, err := d.Client.DoReq(ctx, http.MethodPost, d.path("/_compact"), opts)
 	if err != nil {
 		return err
 	}
@@ -744,7 +757,12 @@ func (d *db) CompactView(ctx context.Context, ddocID string) error {
 	if ddocID == "" {
 		return missingArg("ddocID")
 	}
-	res, err := d.Client.DoReq(ctx, http.MethodPost, d.path("/_compact/"+ddocID), nil)
+	opts := &chttp.Options{
+		Header: http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		},
+	}
+	res, err := d.Client.DoReq(ctx, http.MethodPost, d.path("/_compact/"+ddocID), opts)
 	if err != nil {
 		return err
 	}
@@ -752,7 +770,12 @@ func (d *db) CompactView(ctx context.Context, ddocID string) error {
 }
 
 func (d *db) ViewCleanup(ctx context.Context) error {
-	res, err := d.Client.DoReq(ctx, http.MethodPost, d.path("/_view_cleanup"), nil)
+	opts := &chttp.Options{
+		Header: http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		},
+	}
+	res, err := d.Client.DoReq(ctx, http.MethodPost, d.path("/_view_cleanup"), opts)
 	if err != nil {
 		return err
 	}
@@ -768,6 +791,9 @@ func (d *db) Security(ctx context.Context) (*driver.Security, error) {
 func (d *db) SetSecurity(ctx context.Context, security *driver.Security) error {
 	opts := &chttp.Options{
 		Body: chttp.EncodeBody(security),
+		Header: http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		},
 	}
 	res, err := d.Client.DoReq(ctx, http.MethodPut, d.path("/_security"), opts)
 	if err != nil {
@@ -811,6 +837,9 @@ func (d *db) Purge(ctx context.Context, docMap map[string][]string) (*driver.Pur
 	result := &driver.PurgeResult{}
 	options := &chttp.Options{
 		Body: chttp.EncodeBody(docMap),
+		Header: http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		},
 	}
 	_, err := d.Client.DoJSON(ctx, http.MethodPost, d.path("_purge"), options, &result)
 	return result, err
@@ -821,6 +850,9 @@ var _ driver.RevsDiffer = &db{}
 func (d *db) RevsDiff(ctx context.Context, revMap interface{}) (driver.Rows, error) {
 	options := &chttp.Options{
 		Body: chttp.EncodeBody(revMap),
+		Header: http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		},
 	}
 	resp, err := d.Client.DoReq(ctx, http.MethodPost, d.path("_revs_diff"), options)
 	if err != nil {

--- a/db.go
+++ b/db.go
@@ -342,11 +342,18 @@ func putOpts(doc interface{}, options map[string]interface{}) (*chttp.Options, e
 			}, nil
 		}
 	}
-	return &chttp.Options{
-		Body:       chttp.EncodeBody(doc),
+	opts := &chttp.Options{
+		GetBody:    chttp.BodyEncoder(doc),
 		FullCommit: fullCommit,
 		Query:      params,
-	}, nil
+	}
+	if newEdits, ok := options["new_edits"].(bool); ok && !newEdits {
+		// These are the only PUT requests which are idempotent
+		opts.Header = http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		}
+	}
+	return opts, nil
 }
 
 func (d *db) Put(ctx context.Context, docID string, doc interface{}, options map[string]interface{}) (rev string, err error) {

--- a/db.go
+++ b/db.go
@@ -79,9 +79,9 @@ func (d *db) rowsQuery(ctx context.Context, path string, opts map[string]interfa
 		return nil, err
 	}
 	options := &chttp.Options{Query: query}
-	method := kivik.MethodGet
+	method := http.MethodGet
 	if keys != nil {
-		method = kivik.MethodPost
+		method = http.MethodPost
 		options.Body = chttp.EncodeBody(map[string]interface{}{
 			"keys": keys,
 		})
@@ -311,7 +311,7 @@ func (d *db) CreateDoc(ctx context.Context, doc interface{}, options map[string]
 		Body:       chttp.EncodeBody(doc),
 		FullCommit: fullCommit,
 	}
-	_, err = d.Client.DoJSON(ctx, kivik.MethodPost, path, opts, &result)
+	_, err = d.Client.DoJSON(ctx, http.MethodPost, path, opts, &result)
 	return result.ID, result.Rev, err
 }
 
@@ -358,7 +358,7 @@ func (d *db) Put(ctx context.Context, docID string, doc interface{}, options map
 		ID  string `json:"id"`
 		Rev string `json:"rev"`
 	}
-	_, err = d.Client.DoJSON(ctx, kivik.MethodPut, d.path(chttp.EncodeDocID(docID)), opts, &result)
+	_, err = d.Client.DoJSON(ctx, http.MethodPut, d.path(chttp.EncodeDocID(docID)), opts, &result)
 	if err != nil {
 		return "", err
 	}
@@ -719,7 +719,7 @@ func (d *db) Delete(ctx context.Context, docID, rev string, options map[string]i
 		FullCommit: fullCommit,
 		Query:      query,
 	}
-	resp, err := d.Client.DoReq(ctx, kivik.MethodDelete, d.path(chttp.EncodeDocID(docID)), opts)
+	resp, err := d.Client.DoReq(ctx, http.MethodDelete, d.path(chttp.EncodeDocID(docID)), opts)
 	if err != nil {
 		return "", err
 	}
@@ -728,12 +728,12 @@ func (d *db) Delete(ctx context.Context, docID, rev string, options map[string]i
 }
 
 func (d *db) Flush(ctx context.Context) error {
-	_, err := d.Client.DoError(ctx, kivik.MethodPost, d.path("/_ensure_full_commit"), nil)
+	_, err := d.Client.DoError(ctx, http.MethodPost, d.path("/_ensure_full_commit"), nil)
 	return err
 }
 
 func (d *db) Compact(ctx context.Context) error {
-	res, err := d.Client.DoReq(ctx, kivik.MethodPost, d.path("/_compact"), nil)
+	res, err := d.Client.DoReq(ctx, http.MethodPost, d.path("/_compact"), nil)
 	if err != nil {
 		return err
 	}
@@ -744,7 +744,7 @@ func (d *db) CompactView(ctx context.Context, ddocID string) error {
 	if ddocID == "" {
 		return missingArg("ddocID")
 	}
-	res, err := d.Client.DoReq(ctx, kivik.MethodPost, d.path("/_compact/"+ddocID), nil)
+	res, err := d.Client.DoReq(ctx, http.MethodPost, d.path("/_compact/"+ddocID), nil)
 	if err != nil {
 		return err
 	}
@@ -752,7 +752,7 @@ func (d *db) CompactView(ctx context.Context, ddocID string) error {
 }
 
 func (d *db) ViewCleanup(ctx context.Context) error {
-	res, err := d.Client.DoReq(ctx, kivik.MethodPost, d.path("/_view_cleanup"), nil)
+	res, err := d.Client.DoReq(ctx, http.MethodPost, d.path("/_view_cleanup"), nil)
 	if err != nil {
 		return err
 	}
@@ -761,7 +761,7 @@ func (d *db) ViewCleanup(ctx context.Context) error {
 
 func (d *db) Security(ctx context.Context) (*driver.Security, error) {
 	var sec *driver.Security
-	_, err := d.Client.DoJSON(ctx, kivik.MethodGet, d.path("/_security"), nil, &sec)
+	_, err := d.Client.DoJSON(ctx, http.MethodGet, d.path("/_security"), nil, &sec)
 	return sec, err
 }
 
@@ -769,7 +769,7 @@ func (d *db) SetSecurity(ctx context.Context, security *driver.Security) error {
 	opts := &chttp.Options{
 		Body: chttp.EncodeBody(security),
 	}
-	res, err := d.Client.DoReq(ctx, kivik.MethodPut, d.path("/_security"), opts)
+	res, err := d.Client.DoReq(ctx, http.MethodPut, d.path("/_security"), opts)
 	if err != nil {
 		return err
 	}
@@ -799,7 +799,7 @@ func (d *db) Copy(ctx context.Context, targetID, sourceID string, options map[st
 			chttp.HeaderDestination: []string{targetID},
 		},
 	}
-	resp, err := d.Client.DoReq(ctx, kivik.MethodCopy, d.path(chttp.EncodeDocID(sourceID)), opts)
+	resp, err := d.Client.DoReq(ctx, "COPY", d.path(chttp.EncodeDocID(sourceID)), opts)
 	if err != nil {
 		return "", err
 	}
@@ -812,7 +812,7 @@ func (d *db) Purge(ctx context.Context, docMap map[string][]string) (*driver.Pur
 	options := &chttp.Options{
 		Body: chttp.EncodeBody(docMap),
 	}
-	_, err := d.Client.DoJSON(ctx, kivik.MethodPost, d.path("_purge"), options, &result)
+	_, err := d.Client.DoJSON(ctx, http.MethodPost, d.path("_purge"), options, &result)
 	return result, err
 }
 

--- a/db.go
+++ b/db.go
@@ -82,7 +82,7 @@ func (d *db) rowsQuery(ctx context.Context, path string, opts map[string]interfa
 	method := http.MethodGet
 	if keys != nil {
 		method = http.MethodPost
-		options.Body = chttp.EncodeBody(map[string]interface{}{
+		options.GetBody = chttp.BodyEncoder(map[string]interface{}{
 			"keys": keys,
 		})
 		options.Header = http.Header{
@@ -790,7 +790,7 @@ func (d *db) Security(ctx context.Context) (*driver.Security, error) {
 
 func (d *db) SetSecurity(ctx context.Context, security *driver.Security) error {
 	opts := &chttp.Options{
-		Body: chttp.EncodeBody(security),
+		GetBody: chttp.BodyEncoder(security),
 		Header: http.Header{
 			chttp.HeaderIdempotencyKey: []string{},
 		},
@@ -836,7 +836,7 @@ func (d *db) Copy(ctx context.Context, targetID, sourceID string, options map[st
 func (d *db) Purge(ctx context.Context, docMap map[string][]string) (*driver.PurgeResult, error) {
 	result := &driver.PurgeResult{}
 	options := &chttp.Options{
-		Body: chttp.EncodeBody(docMap),
+		GetBody: chttp.BodyEncoder(docMap),
 		Header: http.Header{
 			chttp.HeaderIdempotencyKey: []string{},
 		},
@@ -849,7 +849,7 @@ var _ driver.RevsDiffer = &db{}
 
 func (d *db) RevsDiff(ctx context.Context, revMap interface{}) (driver.Rows, error) {
 	options := &chttp.Options{
-		Body: chttp.EncodeBody(revMap),
+		GetBody: chttp.BodyEncoder(revMap),
 		Header: http.Header{
 			chttp.HeaderIdempotencyKey: []string{},
 		},

--- a/db_test.go
+++ b/db_test.go
@@ -1205,7 +1205,7 @@ func TestRowsQuery(t *testing.T) {
 				"keys": []string{"_design/_auth", "foo"},
 			},
 			db: newCustomDB(func(r *http.Request) (*http.Response, error) {
-				if r.Method != kivik.MethodPost {
+				if r.Method != http.MethodPost {
 					t.Errorf("Unexpected method: %s", r.Method)
 				}
 				defer r.Body.Close() // nolint: errcheck
@@ -1288,7 +1288,7 @@ func TestRowsQuery(t *testing.T) {
 				"keys": []interface{}{"_design/_auth", "foo", []string{"bar", "baz"}},
 			},
 			db: newCustomDB(func(r *http.Request) (*http.Response, error) {
-				if r.Method != kivik.MethodPost {
+				if r.Method != http.MethodPost {
 					t.Errorf("Unexpected method: %s", r.Method)
 				}
 				defer r.Body.Close() // nolint: errcheck

--- a/dbstats.go
+++ b/dbstats.go
@@ -69,6 +69,9 @@ type dbsInfoResponse struct {
 func (c *client) DBsStats(ctx context.Context, dbnames []string) ([]*driver.DBStats, error) {
 	opts := &chttp.Options{
 		Body: chttp.EncodeBody(dbsInfoRequest{Keys: dbnames}),
+		Header: http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		},
 	}
 	result := []dbsInfoResponse{}
 	_, err := c.DoJSON(context.Background(), http.MethodPost, "/_dbs_info", opts, &result)

--- a/dbstats.go
+++ b/dbstats.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 
 	"github.com/go-kivik/couchdb/chttp"
-	"github.com/go-kivik/kivik"
 	"github.com/go-kivik/kivik/driver"
 )
 
@@ -50,7 +50,7 @@ func (s *dbStats) driverStats() *driver.DBStats {
 
 func (d *db) Stats(ctx context.Context) (*driver.DBStats, error) {
 	result := dbStats{}
-	if _, err := d.Client.DoJSON(ctx, kivik.MethodGet, d.dbName, nil, &result); err != nil {
+	if _, err := d.Client.DoJSON(ctx, http.MethodGet, d.dbName, nil, &result); err != nil {
 		return nil, err
 	}
 	return result.driverStats(), nil
@@ -71,7 +71,7 @@ func (c *client) DBsStats(ctx context.Context, dbnames []string) ([]*driver.DBSt
 		Body: chttp.EncodeBody(dbsInfoRequest{Keys: dbnames}),
 	}
 	result := []dbsInfoResponse{}
-	_, err := c.DoJSON(context.Background(), kivik.MethodPost, "/_dbs_info", opts, &result)
+	_, err := c.DoJSON(context.Background(), http.MethodPost, "/_dbs_info", opts, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/dbstats.go
+++ b/dbstats.go
@@ -68,7 +68,7 @@ type dbsInfoResponse struct {
 
 func (c *client) DBsStats(ctx context.Context, dbnames []string) ([]*driver.DBStats, error) {
 	opts := &chttp.Options{
-		Body: chttp.EncodeBody(dbsInfoRequest{Keys: dbnames}),
+		GetBody: chttp.BodyEncoder(dbsInfoRequest{Keys: dbnames}),
 		Header: http.Header{
 			chttp.HeaderIdempotencyKey: []string{},
 		},

--- a/find.go
+++ b/find.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/go-kivik/couchdb/chttp"
-	"github.com/go-kivik/kivik"
 	"github.com/go-kivik/kivik/driver"
 )
 
@@ -27,7 +27,7 @@ func (d *db) CreateIndex(ctx context.Context, ddoc, name string, index interface
 	opts := &chttp.Options{
 		Body: chttp.EncodeBody(parameters),
 	}
-	_, err = d.Client.DoError(ctx, kivik.MethodPost, d.path("_index"), opts)
+	_, err = d.Client.DoError(ctx, http.MethodPost, d.path("_index"), opts)
 	return err
 }
 
@@ -35,7 +35,7 @@ func (d *db) GetIndexes(ctx context.Context) ([]driver.Index, error) {
 	var result struct {
 		Indexes []driver.Index `json:"indexes"`
 	}
-	_, err := d.Client.DoJSON(ctx, kivik.MethodGet, d.path("_index"), nil, &result)
+	_, err := d.Client.DoJSON(ctx, http.MethodGet, d.path("_index"), nil, &result)
 	return result.Indexes, err
 }
 
@@ -47,7 +47,7 @@ func (d *db) DeleteIndex(ctx context.Context, ddoc, name string) error {
 		return missingArg("name")
 	}
 	path := fmt.Sprintf("_index/%s/json/%s", ddoc, name)
-	_, err := d.Client.DoError(ctx, kivik.MethodDelete, d.path(path), nil)
+	_, err := d.Client.DoError(ctx, http.MethodDelete, d.path(path), nil)
 	return err
 }
 
@@ -55,7 +55,7 @@ func (d *db) Find(ctx context.Context, query interface{}) (driver.Rows, error) {
 	opts := &chttp.Options{
 		Body: chttp.EncodeBody(query),
 	}
-	resp, err := d.Client.DoReq(ctx, kivik.MethodPost, d.path("_find"), opts)
+	resp, err := d.Client.DoReq(ctx, http.MethodPost, d.path("_find"), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (d *db) Explain(ctx context.Context, query interface{}) (*driver.QueryPlan,
 		Body: chttp.EncodeBody(query),
 	}
 	var plan queryPlan
-	if _, err := d.Client.DoJSON(ctx, kivik.MethodPost, d.path("_explain"), opts, &plan); err != nil {
+	if _, err := d.Client.DoJSON(ctx, http.MethodPost, d.path("_explain"), opts, &plan); err != nil {
 		return nil, err
 	}
 	return &driver.QueryPlan{

--- a/find.go
+++ b/find.go
@@ -54,6 +54,9 @@ func (d *db) DeleteIndex(ctx context.Context, ddoc, name string) error {
 func (d *db) Find(ctx context.Context, query interface{}) (driver.Rows, error) {
 	opts := &chttp.Options{
 		Body: chttp.EncodeBody(query),
+		Header: http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		},
 	}
 	resp, err := d.Client.DoReq(ctx, http.MethodPost, d.path("_find"), opts)
 	if err != nil {
@@ -95,6 +98,9 @@ func (f *fields) UnmarshalJSON(data []byte) error {
 func (d *db) Explain(ctx context.Context, query interface{}) (*driver.QueryPlan, error) {
 	opts := &chttp.Options{
 		Body: chttp.EncodeBody(query),
+		Header: http.Header{
+			chttp.HeaderIdempotencyKey: []string{},
+		},
 	}
 	var plan queryPlan
 	if _, err := d.Client.DoJSON(ctx, http.MethodPost, d.path("_explain"), opts, &plan); err != nil {

--- a/find.go
+++ b/find.go
@@ -53,7 +53,7 @@ func (d *db) DeleteIndex(ctx context.Context, ddoc, name string) error {
 
 func (d *db) Find(ctx context.Context, query interface{}) (driver.Rows, error) {
 	opts := &chttp.Options{
-		Body: chttp.EncodeBody(query),
+		GetBody: chttp.BodyEncoder(query),
 		Header: http.Header{
 			chttp.HeaderIdempotencyKey: []string{},
 		},
@@ -97,7 +97,7 @@ func (f *fields) UnmarshalJSON(data []byte) error {
 
 func (d *db) Explain(ctx context.Context, query interface{}) (*driver.QueryPlan, error) {
 	opts := &chttp.Options{
-		Body: chttp.EncodeBody(query),
+		GetBody: chttp.BodyEncoder(query),
 		Header: http.Header{
 			chttp.HeaderIdempotencyKey: []string{},
 		},

--- a/replication.go
+++ b/replication.go
@@ -147,7 +147,7 @@ type activeTask struct {
 }
 
 func (r *replication) updateActiveTasks(ctx context.Context) (*activeTask, error) {
-	resp, err := r.client.DoReq(ctx, kivik.MethodGet, "/_active_tasks", nil)
+	resp, err := r.client.DoReq(ctx, http.MethodGet, "/_active_tasks", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +265,7 @@ func (c *client) legacyGetReplications(ctx context.Context, options map[string]i
 		} `json:"rows"`
 	}
 	path := "/_replicator/_all_docs?" + params.Encode()
-	if _, err = c.DoJSON(ctx, kivik.MethodGet, path, nil, &result); err != nil {
+	if _, err = c.DoJSON(ctx, http.MethodGet, path, nil, &result); err != nil {
 		return nil, err
 	}
 	reps := make([]driver.Replication, 0, len(result.Rows))
@@ -309,7 +309,7 @@ func (c *client) Replicate(ctx context.Context, targetDSN, sourceDSN string, opt
 	var repStub struct {
 		ID string `json:"id"`
 	}
-	if _, e := c.Client.DoJSON(ctx, kivik.MethodPost, "/_replicator", opts, &repStub); e != nil {
+	if _, e := c.Client.DoJSON(ctx, http.MethodPost, "/_replicator", opts, &repStub); e != nil {
 		return nil, e
 	}
 	if scheduler {

--- a/scheduler.go
+++ b/scheduler.go
@@ -75,7 +75,7 @@ func (c *client) schedulerSupported(ctx context.Context) (bool, error) {
 	if c.schedulerDetected != nil {
 		return *c.schedulerDetected, nil
 	}
-	resp, err := c.DoReq(ctx, kivik.MethodHead, "_scheduler/jobs", nil)
+	resp, err := c.DoReq(ctx, http.MethodHead, "_scheduler/jobs", nil)
 	if err != nil {
 		return false, err
 	}
@@ -193,7 +193,7 @@ func isBug1000(err error) bool {
 func (r *schedulerReplication) update(ctx context.Context) error {
 	path := fmt.Sprintf("/_scheduler/docs/%s/%s", r.database, chttp.EncodeDocID(r.docID))
 	var doc schedulerDoc
-	if _, err := r.db.Client.DoJSON(ctx, kivik.MethodGet, path, nil, &doc); err != nil {
+	if _, err := r.db.Client.DoJSON(ctx, http.MethodGet, path, nil, &doc); err != nil {
 		if isBug1000(err) {
 			return r.update(ctx)
 		}
@@ -215,7 +215,7 @@ func (c *client) getReplicationsFromScheduler(ctx context.Context, options map[s
 	if params != nil {
 		path = path + "?" + params.Encode()
 	}
-	if _, err = c.DoJSON(ctx, kivik.MethodGet, path, nil, &result); err != nil {
+	if _, err = c.DoJSON(ctx, http.MethodGet, path, nil, &result); err != nil {
 		return nil, err
 	}
 	reps := make([]driver.Replication, 0, len(result.Docs))

--- a/session.go
+++ b/session.go
@@ -3,8 +3,8 @@ package couchdb
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 
-	"github.com/go-kivik/kivik"
 	"github.com/go-kivik/kivik/driver"
 )
 
@@ -38,7 +38,7 @@ func (s *session) UnmarshalJSON(data []byte) error {
 
 func (c *client) Session(ctx context.Context) (*driver.Session, error) {
 	s := &session{}
-	_, err := c.DoJSON(ctx, kivik.MethodGet, "/_session", nil, s)
+	_, err := c.DoJSON(ctx, http.MethodGet, "/_session", nil, s)
 	return &driver.Session{
 		RawResponse:            s.Data,
 		Name:                   s.UserCtx.Name,

--- a/version.go
+++ b/version.go
@@ -3,15 +3,15 @@ package couchdb
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 
-	"github.com/go-kivik/kivik"
 	"github.com/go-kivik/kivik/driver"
 )
 
 // Version returns the server's version info.
 func (c *client) Version(ctx context.Context) (*driver.Version, error) {
 	i := &info{}
-	_, err := c.DoJSON(ctx, kivik.MethodGet, "/", nil, i)
+	_, err := c.DoJSON(ctx, http.MethodGet, "/", nil, i)
 	return &driver.Version{
 		Version:     i.Version,
 		Vendor:      i.Vendor.Name,


### PR DESCRIPTION
This sets the X-Idempotency-Key header (to empty), and uses the `http.Request.GetBody` method, to allow retrying of certain idempotent requests, in case of network problems.