### PR TITLE
Revert "As a special case, treat PUT ?new_edits=false requests as ide…

### DIFF
--- a/db.go
+++ b/db.go
@@ -342,18 +342,11 @@ func putOpts(doc interface{}, options map[string]interface{}) (*chttp.Options, e
 			}, nil
 		}
 	}
-	opts := &chttp.Options{
-		GetBody:    chttp.BodyEncoder(doc),
+	return &chttp.Options{
+		Body:       chttp.EncodeBody(doc),
 		FullCommit: fullCommit,
 		Query:      params,
-	}
-	if newEdits, ok := options["new_edits"].(bool); ok && !newEdits {
-		// These are the only PUT requests which are idempotent
-		opts.Header = http.Header{
-			chttp.HeaderIdempotencyKey: []string{},
-		}
-	}
-	return opts, nil
+	}, nil
 }
 
 func (d *db) Put(ctx context.Context, docID string, doc interface{}, options map[string]interface{}) (rev string, err error) {


### PR DESCRIPTION
…mpotent"

This reverts commit 02d47d34259cb434c786152066a8652871ceb302.

Unless/until reading an attachment is re-doable, this can't be truly idempotent.