### PR TITLE
Re-authenticate when cookie-based auth session is expired

### DIFF
--- a/chttp/auth.go
+++ b/chttp/auth.go
@@ -11,12 +11,12 @@ type Authenticator interface {
 	Authenticate(*Client) error
 }
 
-func (a *CookieAuth) setCookieJar(c *Client) {
+func (a *CookieAuth) setCookieJar() {
 	// If a jar is already set, just use it
-	if c.Jar != nil {
+	if a.client.Jar != nil {
 		return
 	}
 	// cookiejar.New never returns an error
 	jar, _ := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
-	c.Jar = jar
+	a.client.Jar = jar
 }

--- a/chttp/cookieauth.go
+++ b/chttp/cookieauth.go
@@ -3,6 +3,7 @@ package chttp
 import (
 	"context"
 	"net/http"
+	"time"
 
 	kivik "github.com/go-kivik/kivik/v4"
 )
@@ -35,6 +36,26 @@ func (a *CookieAuth) Authenticate(c *Client) error {
 	return nil
 }
 
+// shouldAuth returns true if there is no cookie set, or if it has expired.
+func (a *CookieAuth) shouldAuth(req *http.Request) bool {
+	if _, err := req.Cookie(kivik.SessionCookieName); err == nil {
+		return false
+	}
+	cookie := a.Cookie()
+	if cookie == nil {
+		return true
+	}
+	if !cookie.Expires.IsZero() {
+		return cookie.Expires.Before(time.Now())
+	}
+	// If we get here, it means the server did not include an expiry time in
+	// the session cookie. Some CouchDB configurations do this, but rather than
+	// re-authenticating for every request, we'll let the session expire. A
+	// future change might be to make a client-configurable option to set the
+	// re-authentication timeout.
+	return false
+}
+
 // Cookie returns the current session cookie if found, or nil if not.
 func (a *CookieAuth) Cookie() *http.Cookie {
 	if a.client == nil {
@@ -64,8 +85,7 @@ func (a *CookieAuth) authenticate(req *http.Request) error {
 	if inProg, _ := ctx.Value(authInProgress).(bool); inProg {
 		return nil
 	}
-	if _, ok := req.Header["Cookie"]; ok {
-		// Request already authenticated
+	if !a.shouldAuth(req) {
 		return nil
 	}
 	a.client.authMU.Lock()

--- a/chttp/cookieauth.go
+++ b/chttp/cookieauth.go
@@ -25,8 +25,8 @@ var _ Authenticator = &CookieAuth{}
 
 // Authenticate initiates a session with the CouchDB server.
 func (a *CookieAuth) Authenticate(c *Client) error {
-	a.setCookieJar(c)
 	a.client = c
+	a.setCookieJar()
 	a.transport = c.Transport
 	if a.transport == nil {
 		a.transport = http.DefaultTransport


### PR DESCRIPTION
Should fix #124 

Although this does not handle the case where the server does not include a session expiry time, which can affect some CouchDB configurations. When the server does not include a session expiry time, the old behavior continues, and the session will eventually expire.