### PR TITLE
Validate DB name, to avoid a parsing error later.

### DIFF
--- a/couchdb.go
+++ b/couchdb.go
@@ -15,6 +15,7 @@ package couchdb
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"sync"
 
 	"github.com/go-kivik/couchdb/v4/chttp"
@@ -86,6 +87,9 @@ func (d *couch) NewClient(dsn string, options map[string]interface{}) (driver.Cl
 func (c *client) DB(dbName string, _ map[string]interface{}) (driver.DB, error) {
 	if dbName == "" {
 		return nil, missingArg("dbName")
+	}
+	if _, err := url.PathUnescape(dbName); err != nil {
+		return nil, &kivik.Error{HTTPStatus: http.StatusBadRequest, Err: err}
 	}
 	return &db{
 		client: c,

--- a/couchdb_test.go
+++ b/couchdb_test.go
@@ -129,6 +129,12 @@ func TestDB(t *testing.T) {
 				dbName: "foo",
 			},
 		},
+		{
+			name:   "invalid dbname",
+			dbName: "%xxx",
+			status: http.StatusBadRequest,
+			err:    `invalid URL escape "%xx"`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Should fix this, when using an invalid DB name:

panic: THIS IS A BUG: d.path failed: parse "//%2F": invalid URL escape "%2F" [recovered]
        panic: THIS IS A BUG: d.path failed: parse "//%2F": invalid URL escape "%2F" [recovered]
        panic: THIS IS A BUG: d.path failed: parse "//%2F": invalid URL escape "%2F"