### PR TITLE
Ensure a multiQueriesRows object closes all resources

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -259,13 +259,17 @@ func (r *multiQueriesRows) Close() error {
 	if atomic.AddInt32(&r.closed, 1) > 1 {
 		return nil
 	}
+	r.dec = nil
+	if r.rows != nil {
+		defer r.rows.Close() // nolint:errcheck
+	}
+	defer r.r.Close() // nolint:errcheck
 	if _, err := ioutil.ReadAll(r.r); err != nil {
 		return err
 	}
 	if err := r.r.Close(); err != nil {
 		return err
 	}
-	r.dec = nil
 	if r.rows == nil {
 		return nil
 	}


### PR DESCRIPTION
...even in case of an error

Backport of https://github.com/go-kivik/couchdb/pull/261