### PR TITLE
Don't require a ContentType for attachments

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -20,9 +20,6 @@ func (d *db) PutAttachment(ctx context.Context, docID, rev string, att *driver.A
 	if att.Filename == "" {
 		return "", missingArg("att.Filename")
 	}
-	if att.ContentType == "" {
-		return "", missingArg("att.ContentType")
-	}
 	if att.Content == nil {
 		return "", missingArg("att.Content")
 	}

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -63,16 +63,6 @@ func TestPutAttachment(t *testing.T) {
 			err:    "kivik: att.Filename required",
 		},
 		{
-			name: "missing content type",
-			id:   "foo",
-			rev:  "1-xxx",
-			att: &driver.Attachment{
-				Filename: "x.jpg",
-			},
-			status: http.StatusBadRequest,
-			err:    "kivik: att.ContentType required",
-		},
-		{
 			name: "no body",
 			id:   "foo",
 			rev:  "1-xxx",


### PR DESCRIPTION
Let the server use its default if it wants to

Backport of #264 