### PR TITLE
Re-authenticate if the cookie is nearing expiration

### DIFF
--- a/chttp/cookieauth.go
+++ b/chttp/cookieauth.go
@@ -58,7 +58,7 @@ func (a *CookieAuth) shouldAuth(req *http.Request) bool {
 		return true
 	}
 	if !cookie.Expires.IsZero() {
-		return cookie.Expires.Before(time.Now())
+		return cookie.Expires.Before(time.Now().Add(time.Minute))
 	}
 	// If we get here, it means the server did not include an expiry time in
 	// the session cookie. Some CouchDB configurations do this, but rather than

--- a/chttp/cookieauth_test.go
+++ b/chttp/cookieauth_test.go
@@ -203,7 +203,7 @@ func Test_shouldAuth(t *testing.T) {
 		c, _ := New("http://example.com/")
 		c.Jar = &dummyJar{&http.Cookie{
 			Name:    kivik.SessionCookieName,
-			Expires: time.Now().Add(20 * time.Second),
+			Expires: time.Now().Add(20 * time.Minute),
 		}}
 		a := &CookieAuth{client: c}
 
@@ -238,6 +238,20 @@ func Test_shouldAuth(t *testing.T) {
 			a:    a,
 			req:  httptest.NewRequest("GET", "/", nil),
 			want: false,
+		}
+	})
+	tests.Add("about to expire", func() interface{} {
+		c, _ := New("http://example.com/")
+		c.Jar = &dummyJar{&http.Cookie{
+			Name:    kivik.SessionCookieName,
+			Expires: time.Now().Add(20 * time.Second),
+		}}
+		a := &CookieAuth{client: c}
+
+		return tt{
+			a:    a,
+			req:  httptest.NewRequest("GET", "/", nil),
+			want: true,
 		}
 	})
 

--- a/chttp/cookieauth_test.go
+++ b/chttp/cookieauth_test.go
@@ -335,19 +335,12 @@ func Test401Response(t *testing.T) {
 	_, err = c.DoError(context.Background(), "GET", "/foo", nil)
 
 	// this causes a skip so this won't work for us.
-	//testy.StatusError(t, "Unauthorized: You are not authorized to access this db.", 401, err)
-	if err == nil {
-		t.Fatal("Should have an auth error")
+	// testy.StatusError(t, "Unauthorized: You are not authorized to access this db.", 401, err)
+	if !testy.ErrorMatches("Unauthorized: You are not authorized to access this db.", err) {
+		t.Fatalf("Unexpected error: %s", err)
 	}
-	if err != nil {
-		errString := err.Error()
-		if errString != "Unauthorized: You are not authorized to access this db." {
-			t.Errorf("Unexpected error: %s", err)
-		}
-		actualStatus := testy.StatusCode(err)
-		if 401 != actualStatus {
-			t.Errorf("Unexpected status code: %d (expected %d)", actualStatus, 401)
-		}
+	if status := testy.StatusCode(err); status != http.StatusUnauthorized {
+		t.Errorf("Unexpected status code: %d", status)
 	}
 
 	var noCookie *http.Cookie


### PR DESCRIPTION
This is to work around time sync issues, which are practically inevitable,
so that requests made right when a cookie is expiring won't fail.