### PR TITLE
Add gzip support for requests and responses

### DIFF
--- a/chttp/chttp.go
+++ b/chttp/chttp.go
@@ -221,7 +221,12 @@ func (c *Client) shouldCompressBody(path string, body io.Reader, opts *Options) 
 		return false
 	}
 	// /_session only supports compression from CouchDB 3.2.
-	if strings.HasSuffix(path, "/_session") {
+	parsed, err := url.Parse(path)
+	if err != nil {
+		// should never happen
+		return true
+	}
+	if strings.HasSuffix(parsed.Path, "/_session") {
 		return false
 	}
 	if body == nil {

--- a/chttp/chttp.go
+++ b/chttp/chttp.go
@@ -169,8 +169,8 @@ func DecodeJSON(r *http.Response, i interface{}) error {
 	return nil
 }
 
-// DoJSON combines DoReq() and, ResponseError(), and (*Response).DecodeJSON(), and
-// closes the response body.
+// DoJSON combines [Client.DoReq], [Client.ResponseError], and
+// [Response.DecodeJSON], and closes the response body.
 func (c *Client) DoJSON(ctx context.Context, method, path string, opts *Options, i interface{}) error {
 	res, err := c.DoReq(ctx, method, path, opts)
 	if err != nil {

--- a/chttp/options.go
+++ b/chttp/options.go
@@ -63,6 +63,9 @@ type Options struct {
 
 	// Header is a list of default headers to be set on the request.
 	Header http.Header
+
+	// NoGzip disables gzip compression on the request body.
+	NoGzip bool
 }
 
 // NewOptions converts a kivik options map into

--- a/constants.go
+++ b/constants.go
@@ -59,6 +59,10 @@ const (
 	// multipart/related media type. This only affects GET requests that request
 	// attachments.
 	OptionNoMultipartGet = internal.OptionNoMultipartGet
+
+	// OptionNoCompressedRequests disables gzip content encoding for request
+	// bodies. Only valid as an option to [github.com/go-kivik/kivik/v4.New].
+	OptionNoCompressedRequests = internal.OptionNoCompressedRequests
 )
 
 const (

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -15,11 +15,12 @@ package internal
 // Common constants, placed here to allow importing in chttp and root package
 // without import cycles.
 const (
-	OptionUserAgent      = "User-Agent"
-	OptionHTTPClient     = "kivik:httpClient"
-	OptionFullCommit     = "X-Couch-Full-Commit"
-	OptionIfNoneMatch    = "If-None-Match"
-	OptionPartition      = "kivik:partition"
-	OptionNoMultipartPut = "kivik:no-multipart-put"
-	OptionNoMultipartGet = "kivik:no-multipart-get"
+	OptionUserAgent            = "User-Agent"
+	OptionHTTPClient           = "kivik:httpClient"
+	OptionFullCommit           = "X-Couch-Full-Commit"
+	OptionIfNoneMatch          = "If-None-Match"
+	OptionPartition            = "kivik:partition"
+	OptionNoMultipartPut       = "kivik:no-multipart-put"
+	OptionNoMultipartGet       = "kivik:no-multipart-get"
+	OptionNoCompressedRequests = "kivik:no-compressed-requests"
 )

--- a/mock_test.go
+++ b/mock_test.go
@@ -130,7 +130,9 @@ func realDB(t *testing.T) *db {
 
 func realDBConnect(t *testing.T) (*db, error) {
 	driver := &couch{}
-	c, err := driver.NewClient(kt.DSN(t), nil)
+	c, err := driver.NewClient(kt.DSN(t), map[string]interface{}{
+		OptionNoCompressedRequests: true,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/mock_test.go
+++ b/mock_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/go-kivik/couchdb/v4/chttp"
+	"github.com/go-kivik/couchdb/v4/internal"
 	"github.com/go-kivik/kiviktest/v4/kt"
 )
 
@@ -64,7 +65,9 @@ func newTestClient(response *http.Response, err error) *client {
 }
 
 func newCustomClient(fn func(*http.Request) (*http.Response, error)) *client {
-	chttpClient, _ := chttp.New(&http.Client{}, "http://example.com/", nil)
+	chttpClient, _ := chttp.New(&http.Client{}, "http://example.com/", map[string]interface{}{
+		internal.OptionNoCompressedRequests: true,
+	})
 	chttpClient.Client.Transport = customTransport(fn)
 	return &client{
 		Client: chttpClient,

--- a/test/session.go
+++ b/test/session.go
@@ -346,7 +346,7 @@ func testDeleteSession(ctx *kt.Context, client *chttp.Client) {
 				response := struct {
 					OK bool `json:"ok"`
 				}{}
-				req, err := client.NewRequest(context.Background(), http.MethodDelete, "/_session", nil)
+				req, err := client.NewRequest(context.Background(), http.MethodDelete, "/_session", nil, nil)
 				if err != nil {
 					ctx.Fatalf("Failed to create request: %s", err)
 				}


### PR DESCRIPTION
Fixes #288, except for POSTs to /_session, which is only supported in CouchDB 3.3.  #325 is tracking adding conditional support for this endpoint.