### PR TITLE
Revert "Add Accept-Encoding: gzip header to requests"

### DIFF
--- a/chttp/chttp.go
+++ b/chttp/chttp.go
@@ -351,7 +351,6 @@ func setHeaders(req *http.Request, opts *Options) {
 	}
 	req.Header.Add("Accept", accept)
 	req.Header.Add("Content-Type", contentType)
-	req.Header.Add("Accept-Encoding", "gzip")
 }
 
 func setQuery(req *http.Request, opts *Options) {

--- a/chttp/chttp_test.go
+++ b/chttp/chttp_test.go
@@ -257,27 +257,24 @@ func TestSetHeaders(t *testing.T) {
 		{
 			Name: "NoOpts",
 			Expected: http.Header{
-				"Accept":          {"application/json"},
-				"Content-Type":    {"application/json"},
-				"Accept-Encoding": {"gzip"},
+				"Accept":       {"application/json"},
+				"Content-Type": {"application/json"},
 			},
 		},
 		{
 			Name:    "Content-Type",
 			Options: &Options{ContentType: "image/gif"},
 			Expected: http.Header{
-				"Accept":          {"application/json"},
-				"Accept-Encoding": {"gzip"},
-				"Content-Type":    {"image/gif"},
+				"Accept":       {"application/json"},
+				"Content-Type": {"image/gif"},
 			},
 		},
 		{
 			Name:    "Accept",
 			Options: &Options{Accept: "image/gif"},
 			Expected: http.Header{
-				"Accept":          {"image/gif"},
-				"Content-Type":    {"application/json"},
-				"Accept-Encoding": {"gzip"},
+				"Accept":       {"image/gif"},
+				"Content-Type": {"application/json"},
 			},
 		},
 		{
@@ -286,7 +283,6 @@ func TestSetHeaders(t *testing.T) {
 			Expected: http.Header{
 				"Accept":              {"application/json"},
 				"Content-Type":        {"application/json"},
-				"Accept-Encoding":     {"gzip"},
 				"X-Couch-Full-Commit": {"true"},
 			},
 		},
@@ -296,30 +292,27 @@ func TestSetHeaders(t *testing.T) {
 				HeaderDestination: []string{"somewhere nice"},
 			}},
 			Expected: http.Header{
-				"Accept":          {"application/json"},
-				"Content-Type":    {"application/json"},
-				"Accept-Encoding": {"gzip"},
-				"Destination":     {"somewhere nice"},
+				"Accept":       {"application/json"},
+				"Content-Type": {"application/json"},
+				"Destination":  {"somewhere nice"},
 			},
 		},
 		{
 			Name:    "If-None-Match",
 			Options: &Options{IfNoneMatch: `"foo"`},
 			Expected: http.Header{
-				"Accept":          {"application/json"},
-				"Content-Type":    {"application/json"},
-				"Accept-Encoding": {"gzip"},
-				"If-None-Match":   {`"foo"`},
+				"Accept":        {"application/json"},
+				"Content-Type":  {"application/json"},
+				"If-None-Match": {`"foo"`},
 			},
 		},
 		{
 			Name:    "Unquoted If-None-Match",
 			Options: &Options{IfNoneMatch: `foo`},
 			Expected: http.Header{
-				"Accept":          {"application/json"},
-				"Content-Type":    {"application/json"},
-				"Accept-Encoding": {"gzip"},
-				"If-None-Match":   {`"foo"`},
+				"Accept":        {"application/json"},
+				"Content-Type":  {"application/json"},
+				"If-None-Match": {`"foo"`},
 			},
 		},
 	}
@@ -745,7 +738,6 @@ func TestDoReq(t *testing.T) {
 					expected := httptest.NewRequest("PUT", "/foo", nil)
 					expected.Header.Add("Accept", "application/json")
 					expected.Header.Add("Content-Type", "application/json")
-					expected.Header.Add("Accept-Encoding", "gzip")
 					expected.Header.Add("User-Agent", defaultUA)
 					if d := testy.DiffHTTPRequest(expected, r); d != nil {
 						t.Error(d)
@@ -772,7 +764,6 @@ func TestDoReq(t *testing.T) {
 					expected := httptest.NewRequest("PUT", "/foo", Body("bar"))
 					expected.Header.Add("Accept", "application/json")
 					expected.Header.Add("Content-Type", "application/json")
-					expected.Header.Add("Accept-Encoding", "gzip")
 					expected.Header.Add("User-Agent", defaultUA)
 					if d := testy.DiffHTTPRequest(expected, r); d != nil {
 						t.Error(d)


### PR DESCRIPTION
This reverts commit 01ae08751ce5e00553e5f448806b9ff07dc14511.

TIL this is automatically handled by the default transport. See DisableCompression option.